### PR TITLE
fix Batch init for types other than number and bool

### DIFF
--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -114,7 +114,7 @@ class Batch:
         >>> print(data[0])
         Batch(
             a: Batch(
-                b: array(['0.0', 'info'], dtype='<U32'),
+                b: array([0.0, 'info'], dtype=object),
             ),
         )
 
@@ -224,7 +224,7 @@ class Batch:
         Batch(
             a: array([False,  True]),
             b: Batch(
-                   c: array([0., 3.]),
+                   c: array([None, 'st']),
                    d: array([0., 0.]),
                ),
         )
@@ -270,6 +270,9 @@ class Batch:
                 else:
                     if isinstance(v, list):
                         v = np.array(v)
+                        if not np.issubdtype(v.dtype, np.bool_) and \
+                                not np.issubdtype(v.dtype, np.number):
+                            v = v.astype(np.object)
                     self.__dict__[k] = v
         if len(kwargs) > 0:
             self.__init__(kwargs, copy=copy)
@@ -525,7 +528,11 @@ class Batch:
             elif isinstance(v[0], torch.Tensor):
                 self.__dict__[k] = torch.stack(v, axis)
             else:
-                self.__dict__[k] = np.stack(v, axis)
+                v = np.stack(v, axis)
+                if not np.issubdtype(v.dtype, np.bool_) and \
+                        not np.issubdtype(v.dtype, np.number):
+                    v = v.astype(np.object)
+                self.__dict__[k] = v
         keys_partial = reduce(set.symmetric_difference, keys_map)
         for k in keys_partial:
             for i, e in enumerate(batches):

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -87,9 +87,9 @@ class Batch:
 
     In short, you can define a :class:`Batch` with any key-value pair.
 
-    For Numpy arrays, only data types with ``np.object`` and numbers are
-    supported. For strings or other data types, however, they can be held
-    in ``np.object`` arrays.
+    For Numpy arrays, only data types with ``np.object``, bool, and number
+    are supported. For strings or other data types, however, they can be
+    held in ``np.object`` arrays.
 
     The current implementation of Tianshou typically use 7 reserved keys in
     :class:`~tianshou.data.Batch`:

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -270,8 +270,7 @@ class Batch:
                 else:
                     if isinstance(v, list):
                         v = np.array(v)
-                        if not np.issubdtype(v.dtype, np.bool_) and \
-                                not np.issubdtype(v.dtype, np.number):
+                        if not issubclass(v.dtype.type, (np.bool_, np.number)):
                             v = v.astype(np.object)
                     self.__dict__[k] = v
         if len(kwargs) > 0:
@@ -529,8 +528,7 @@ class Batch:
                 self.__dict__[k] = torch.stack(v, axis)
             else:
                 v = np.stack(v, axis)
-                if not np.issubdtype(v.dtype, np.bool_) and \
-                        not np.issubdtype(v.dtype, np.number):
+                if not issubclass(v.dtype.type, (np.bool_, np.number)):
                     v = v.astype(np.object)
                 self.__dict__[k] = v
         keys_partial = reduce(set.symmetric_difference, keys_map)


### PR DESCRIPTION
- [ ] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [ ] algorithm implementation fix
    + [ ] documentation modification
    + [ ] new feature
- [ ] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [ ] I have visited the [source website], and in particular read the [known issues]
- [ ] I have searched through the [issue tracker] and [issue categories] for duplicates
- [ ] I have mentioned version numbers, operating system and environment, where applicable:
  ```python
  import tianshou, torch, sys
  print(tianshou.__version__, torch.__version__, sys.version, sys.platform)
  ```

  [source website]: https://github.com/thu-ml/tianshou
  [known issues]: https://github.com/thu-ml/tianshou/#faq-and-known-issues
  [issue categories]: https://github.com/thu-ml/tianshou/projects/2
  [issue tracker]: https://github.com/thu-ml/tianshou/issues?q=
