### PR TITLE
fix: restore parameters on TRPO line search failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased Changes
 
 Fixes:
+* `algorithm`:
+  * `TRPO`: Fix original policy parameters not being restored upon line search failure #1287
 * `highlevel.experiment`:
   * Fix `Experiment.run` returning `ExperimentResult` with `trainer_result` unset (None) #1288 
 

--- a/tianshou/algorithm/modelfree/trpo.py
+++ b/tianshou/algorithm/modelfree/trpo.py
@@ -183,7 +183,7 @@ class TRPO(NPG):
                         if i < self.max_backtracks - 1:
                             step_size = step_size * self.backtrack_coeff
                         else:
-                            self._set_from_flat_params(self.policy.actor, new_flat_params)
+                            self._set_from_flat_params(self.policy.actor, flat_params)
                             step_size = torch.tensor([0.0])
                             warnings.warn(
                                 "Line search failed! It seems hyperparamters"


### PR DESCRIPTION
## Bug
When the TRPO line search fails to find a step that satisfies the KL constraint, the original policy parameters are not restored. This leaves the policy with an untested update that violates the trust region.

## Fix
Added parameter restoration to the line search fallback path.