### PR TITLE
Move atari/mujoco helpers into package code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+**Improvements:**
+* `env`:
+  * Move atari/mujoco helper modules from `examples/` into `tianshou.env.atari` and `tianshou.env.mujoco`, with backward-compatible re-export shims #1293
+
 # Release 2.0.1 (2026-04-02)
 
 This is a maintenance release.

--- a/examples/atari/atari_c51.py
+++ b/examples/atari/atari_c51.py
@@ -14,8 +14,7 @@ from tianshou.algorithm.algorithm_base import Algorithm
 from tianshou.algorithm.modelfree.c51 import C51Policy
 from tianshou.algorithm.optim import AdamOptimizerFactory
 from tianshou.data import Collector, CollectStats, VectorReplayBuffer
-from tianshou.env.atari.atari_network import C51Net
-from tianshou.env.atari.atari_wrapper import make_atari_env
+from tianshou.env.atari import C51Net, make_atari_env
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OffPolicyTrainerParams
 

--- a/examples/atari/atari_dqn.py
+++ b/examples/atari/atari_dqn.py
@@ -15,8 +15,7 @@ from tianshou.algorithm.modelbased.icm import ICMOffPolicyWrapper
 from tianshou.algorithm.modelfree.dqn import DiscreteQLearningPolicy
 from tianshou.algorithm.optim import AdamOptimizerFactory
 from tianshou.data import Collector, CollectStats, VectorReplayBuffer
-from tianshou.env.atari.atari_network import DQNet
-from tianshou.env.atari.atari_wrapper import make_atari_env
+from tianshou.env.atari import DQNet, make_atari_env
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OffPolicyTrainerParams
 from tianshou.utils.net.discrete import IntrinsicCuriosityModule

--- a/examples/atari/atari_dqn_hl.py
+++ b/examples/atari/atari_dqn_hl.py
@@ -5,10 +5,11 @@ from typing import Literal
 
 from sensai.util import logging
 
-from tianshou.env.atari.atari_network import (
+from tianshou.env.atari import (
+    AtariEnvFactory,
+    AtariEpochStopCallback,
     IntermediateModuleFactoryAtariDQN,
 )
-from tianshou.env.atari.atari_wrapper import AtariEnvFactory, AtariEpochStopCallback
 from tianshou.highlevel.config import OffPolicyTrainingConfig
 from tianshou.highlevel.experiment import (
     DQNExperimentBuilder,

--- a/examples/atari/atari_fqf.py
+++ b/examples/atari/atari_fqf.py
@@ -14,8 +14,7 @@ from tianshou.algorithm.algorithm_base import Algorithm
 from tianshou.algorithm.modelfree.fqf import FQFPolicy
 from tianshou.algorithm.optim import AdamOptimizerFactory, RMSpropOptimizerFactory
 from tianshou.data import Collector, CollectStats, VectorReplayBuffer
-from tianshou.env.atari.atari_network import DQNet
-from tianshou.env.atari.atari_wrapper import make_atari_env
+from tianshou.env.atari import DQNet, make_atari_env
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OffPolicyTrainerParams
 from tianshou.utils.net.discrete import FractionProposalNetwork, FullQuantileFunction

--- a/examples/atari/atari_iqn.py
+++ b/examples/atari/atari_iqn.py
@@ -14,8 +14,7 @@ from tianshou.algorithm.algorithm_base import Algorithm
 from tianshou.algorithm.modelfree.iqn import IQNPolicy
 from tianshou.algorithm.optim import AdamOptimizerFactory
 from tianshou.data import Collector, CollectStats, VectorReplayBuffer
-from tianshou.env.atari.atari_network import DQNet
-from tianshou.env.atari.atari_wrapper import make_atari_env
+from tianshou.env.atari import DQNet, make_atari_env
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OffPolicyTrainerParams
 from tianshou.utils.net.discrete import ImplicitQuantileNetwork

--- a/examples/atari/atari_iqn_hl.py
+++ b/examples/atari/atari_iqn_hl.py
@@ -5,10 +5,11 @@ from typing import Literal
 
 from sensai.util import logging
 
-from tianshou.env.atari.atari_network import (
+from tianshou.env.atari import (
+    AtariEnvFactory,
+    AtariEpochStopCallback,
     IntermediateModuleFactoryAtariDQN,
 )
-from tianshou.env.atari.atari_wrapper import AtariEnvFactory, AtariEpochStopCallback
 from tianshou.highlevel.config import OffPolicyTrainingConfig
 from tianshou.highlevel.experiment import (
     ExperimentConfig,

--- a/examples/atari/atari_ppo.py
+++ b/examples/atari/atari_ppo.py
@@ -17,12 +17,12 @@ from tianshou.algorithm.modelbased.icm import ICMOnPolicyWrapper
 from tianshou.algorithm.modelfree.reinforce import DiscreteActorPolicy
 from tianshou.algorithm.optim import AdamOptimizerFactory, LRSchedulerFactoryLinear
 from tianshou.data import Collector, CollectStats, VectorReplayBuffer
-from tianshou.env.atari.atari_network import (
+from tianshou.env.atari import (
     DQNet,
     ScaledObsInputActionReprNet,
     layer_init,
+    make_atari_env,
 )
-from tianshou.env.atari.atari_wrapper import make_atari_env
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OnPolicyTrainerParams
 from tianshou.utils.net.discrete import (

--- a/examples/atari/atari_ppo_hl.py
+++ b/examples/atari/atari_ppo_hl.py
@@ -5,10 +5,11 @@ from typing import Literal
 
 from sensai.util import logging
 
-from tianshou.env.atari.atari_network import (
+from tianshou.env.atari import (
     ActorFactoryAtariDQN,
+    AtariEnvFactory,
+    AtariEpochStopCallback,
 )
-from tianshou.env.atari.atari_wrapper import AtariEnvFactory, AtariEpochStopCallback
 from tianshou.highlevel.config import OnPolicyTrainingConfig
 from tianshou.highlevel.experiment import (
     ExperimentConfig,

--- a/examples/atari/atari_qrdqn.py
+++ b/examples/atari/atari_qrdqn.py
@@ -14,8 +14,7 @@ from tianshou.algorithm.algorithm_base import Algorithm
 from tianshou.algorithm.modelfree.qrdqn import QRDQNPolicy
 from tianshou.algorithm.optim import AdamOptimizerFactory
 from tianshou.data import Collector, CollectStats, VectorReplayBuffer
-from tianshou.env.atari.atari_network import QRDQNet
-from tianshou.env.atari.atari_wrapper import make_atari_env
+from tianshou.env.atari import QRDQNet, make_atari_env
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OffPolicyTrainerParams
 

--- a/examples/atari/atari_rainbow.py
+++ b/examples/atari/atari_rainbow.py
@@ -19,8 +19,7 @@ from tianshou.data import (
     PrioritizedVectorReplayBuffer,
     VectorReplayBuffer,
 )
-from tianshou.env.atari.atari_network import RainbowNet
-from tianshou.env.atari.atari_wrapper import make_atari_env
+from tianshou.env.atari import RainbowNet, make_atari_env
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OffPolicyTrainerParams
 

--- a/examples/atari/atari_sac.py
+++ b/examples/atari/atari_sac.py
@@ -15,8 +15,7 @@ from tianshou.algorithm.modelfree.discrete_sac import DiscreteSACPolicy
 from tianshou.algorithm.modelfree.sac import AutoAlpha
 from tianshou.algorithm.optim import AdamOptimizerFactory
 from tianshou.data import Collector, CollectStats, VectorReplayBuffer
-from tianshou.env.atari.atari_network import DQNet
-from tianshou.env.atari.atari_wrapper import make_atari_env
+from tianshou.env.atari import DQNet, make_atari_env
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OffPolicyTrainerParams
 from tianshou.utils.net.discrete import (

--- a/examples/atari/atari_sac_hl.py
+++ b/examples/atari/atari_sac_hl.py
@@ -5,10 +5,11 @@ from typing import Literal
 
 from sensai.util import logging
 
-from tianshou.env.atari.atari_network import (
+from tianshou.env.atari import (
     ActorFactoryAtariDQN,
+    AtariEnvFactory,
+    AtariEpochStopCallback,
 )
-from tianshou.env.atari.atari_wrapper import AtariEnvFactory, AtariEpochStopCallback
 from tianshou.highlevel.config import OffPolicyTrainingConfig
 from tianshou.highlevel.experiment import (
     DiscreteSACExperimentBuilder,

--- a/examples/mujoco/mujoco_a2c.py
+++ b/examples/mujoco/mujoco_a2c.py
@@ -7,7 +7,6 @@ from typing import Literal
 
 import numpy as np
 import torch
-from mujoco_env import make_mujoco_env
 from sensai.util import logging
 from torch import nn
 from torch.distributions import Distribution, Independent, Normal
@@ -17,6 +16,7 @@ from tianshou.algorithm.algorithm_base import Algorithm
 from tianshou.algorithm.modelfree.reinforce import ProbabilisticActorPolicy
 from tianshou.algorithm.optim import LRSchedulerFactoryLinear, RMSpropOptimizerFactory
 from tianshou.data import Collector, CollectStats, ReplayBuffer, VectorReplayBuffer
+from tianshou.env.mujoco import make_mujoco_env
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OnPolicyTrainerParams
 from tianshou.utils.net.common import ActorCritic, Net

--- a/examples/mujoco/mujoco_a2c.py
+++ b/examples/mujoco/mujoco_a2c.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 import numpy as np
 import torch
+from gymnasium.spaces import Box
 from sensai.util import logging
 from torch import nn
 from torch.distributions import Distribution, Independent, Normal
@@ -72,8 +73,10 @@ def main(
         num_test_envs,
         obs_norm=True,
     )
-    state_shape = env.observation_space.shape or env.observation_space.n
-    action_shape = env.action_space.shape or env.action_space.n
+    assert isinstance(env.observation_space, Box)
+    assert isinstance(env.action_space, Box)
+    state_shape = env.observation_space.shape
+    action_shape = env.action_space.shape
     max_action = env.action_space.high[0]
     log.info(f"Observations shape: {state_shape}")
     log.info(f"Actions shape: {action_shape}")

--- a/examples/mujoco/mujoco_a2c_hl.py
+++ b/examples/mujoco/mujoco_a2c_hl.py
@@ -6,7 +6,7 @@ from typing import Literal
 import torch
 from sensai.util import logging
 
-from examples.mujoco.mujoco_env import MujocoEnvFactory
+from tianshou.env.mujoco import MujocoEnvFactory
 from tianshou.highlevel.config import OnPolicyTrainingConfig
 from tianshou.highlevel.experiment import (
     A2CExperimentBuilder,

--- a/examples/mujoco/mujoco_ddpg.py
+++ b/examples/mujoco/mujoco_ddpg.py
@@ -6,7 +6,6 @@ import pprint
 
 import numpy as np
 import torch
-from mujoco_env import make_mujoco_env
 from sensai.util import logging
 
 from tianshou.algorithm import DDPG
@@ -14,6 +13,7 @@ from tianshou.algorithm.algorithm_base import Algorithm
 from tianshou.algorithm.modelfree.ddpg import ContinuousDeterministicPolicy
 from tianshou.algorithm.optim import AdamOptimizerFactory
 from tianshou.data import Collector, CollectStats, ReplayBuffer, VectorReplayBuffer
+from tianshou.env.mujoco import make_mujoco_env
 from tianshou.exploration import GaussianNoise
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OffPolicyTrainerParams

--- a/examples/mujoco/mujoco_ddpg.py
+++ b/examples/mujoco/mujoco_ddpg.py
@@ -6,6 +6,7 @@ import pprint
 
 import numpy as np
 import torch
+from gymnasium.spaces import Box
 from sensai.util import logging
 
 from tianshou.algorithm import DDPG
@@ -68,8 +69,10 @@ def main(
         num_test_envs,
         obs_norm=False,
     )
-    state_shape = env.observation_space.shape or env.observation_space.n
-    action_shape = env.action_space.shape or env.action_space.n
+    assert isinstance(env.observation_space, Box)
+    assert isinstance(env.action_space, Box)
+    state_shape = env.observation_space.shape
+    action_shape = env.action_space.shape
     max_action = env.action_space.high[0]
     exploration_noise = exploration_noise * max_action
     log.info(f"Observations shape: {state_shape}")

--- a/examples/mujoco/mujoco_ddpg_hl.py
+++ b/examples/mujoco/mujoco_ddpg_hl.py
@@ -5,7 +5,7 @@ from typing import Literal
 
 from sensai.util import logging
 
-from examples.mujoco.mujoco_env import MujocoEnvFactory
+from tianshou.env.mujoco import MujocoEnvFactory
 from tianshou.highlevel.config import OffPolicyTrainingConfig
 from tianshou.highlevel.experiment import (
     DDPGExperimentBuilder,

--- a/examples/mujoco/mujoco_env.py
+++ b/examples/mujoco/mujoco_env.py
@@ -1,109 +1,15 @@
-import logging
-import pickle
+"""Backward compatibility shim.
 
-from gymnasium import Env
+The mujoco environment helpers have been moved to ``tianshou.env.mujoco``.
+This module re-exports them so that existing code using
+``from examples.mujoco.mujoco_env import ...`` or
+``from mujoco_env import ...`` continues to work.
+"""
 
-from tianshou.env import BaseVectorEnv, VectorEnvNormObs
-from tianshou.highlevel.env import (
-    ContinuousEnvironments,
-    EnvFactoryRegistered,
-    EnvMode,
-    EnvPoolFactory,
-    VectorEnvType,
-)
-from tianshou.highlevel.persistence import Persistence, PersistEvent, RestoreEvent
-from tianshou.highlevel.world import World
+from tianshou.env.mujoco import MujocoEnvFactory, MujocoEnvObsRmsPersistence, make_mujoco_env
 
-envpool_is_available = True
-try:
-    import envpool
-except ImportError:
-    envpool_is_available = False
-    envpool = None
-
-log = logging.getLogger(__name__)
-
-
-def make_mujoco_env(
-    task: str,
-    seed: int,
-    num_training_envs: int,
-    num_test_envs: int,
-    obs_norm: bool,
-) -> tuple[Env, BaseVectorEnv, BaseVectorEnv]:
-    """Wrapper function for Mujoco env.
-
-    If EnvPool is installed, it will automatically switch to EnvPool's Mujoco env.
-
-    :return: a tuple of (single env, training envs, test envs).
-    """
-    envs = MujocoEnvFactory(task, obs_norm=obs_norm).create_envs(
-        num_training_envs,
-        num_test_envs,
-        seed=seed,
-    )
-    return envs.env, envs.training_envs, envs.test_envs
-
-
-class MujocoEnvObsRmsPersistence(Persistence):
-    FILENAME = "env_obs_rms.pkl"
-
-    def persist(self, event: PersistEvent, world: World) -> None:
-        if event != PersistEvent.PERSIST_POLICY:
-            return  # type: ignore[unreachable]  # since PersistEvent has only one member, mypy infers that line is unreachable
-        obs_rms = world.envs.training_envs.get_obs_rms()
-        path = world.persist_path(self.FILENAME)
-        log.info(f"Saving environment obs_rms value to {path}")
-        with open(path, "wb") as f:
-            pickle.dump(obs_rms, f)
-
-    def restore(self, event: RestoreEvent, world: World) -> None:
-        if event != RestoreEvent.RESTORE_POLICY:
-            return  # type: ignore[unreachable]
-        path = world.restore_path(self.FILENAME)
-        log.info(f"Restoring environment obs_rms value from {path}")
-        with open(path, "rb") as f:
-            obs_rms = pickle.load(f)
-        world.envs.training_envs.set_obs_rms(obs_rms)
-        world.envs.test_envs.set_obs_rms(obs_rms)
-        if world.envs.watch_env is not None:
-            world.envs.watch_env.set_obs_rms(obs_rms)
-
-
-class MujocoEnvFactory(EnvFactoryRegistered):
-    def __init__(
-        self,
-        task: str,
-        obs_norm: bool = True,
-        venv_type: VectorEnvType = VectorEnvType.SUBPROC_SHARED_MEM_AUTO,
-    ) -> None:
-        super().__init__(
-            task=task,
-            venv_type=venv_type,
-            envpool_factory=EnvPoolFactory() if envpool_is_available else None,
-        )
-        self.obs_norm = obs_norm
-
-    def create_venv(self, num_envs: int, mode: EnvMode, seed: int | None = None) -> BaseVectorEnv:
-        env = super().create_venv(num_envs, mode, seed=seed)
-        # obs norm wrapper
-        if self.obs_norm:
-            env = VectorEnvNormObs(env, update_obs_rms=mode == EnvMode.TRAINING)
-        return env
-
-    def create_envs(
-        self,
-        num_training_envs: int,
-        num_test_envs: int,
-        create_watch_env: bool = False,
-        seed: int | None = None,
-    ) -> ContinuousEnvironments:
-        envs = super().create_envs(num_training_envs, num_test_envs, create_watch_env, seed=seed)
-        assert isinstance(envs, ContinuousEnvironments)
-
-        if self.obs_norm:
-            envs.test_envs.set_obs_rms(envs.training_envs.get_obs_rms())
-            if envs.watch_env is not None:
-                envs.watch_env.set_obs_rms(envs.training_envs.get_obs_rms())
-            envs.set_persistence(MujocoEnvObsRmsPersistence())
-        return envs
+__all__ = [
+    "MujocoEnvFactory",
+    "MujocoEnvObsRmsPersistence",
+    "make_mujoco_env",
+]

--- a/examples/mujoco/mujoco_npg.py
+++ b/examples/mujoco/mujoco_npg.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 import numpy as np
 import torch
+from gymnasium.spaces import Box
 from sensai.util import logging
 from torch import nn
 from torch.distributions import Distribution, Independent, Normal
@@ -72,8 +73,10 @@ def main(
         num_test_envs,
         obs_norm=True,
     )
-    state_shape = env.observation_space.shape or env.observation_space.n
-    action_shape = env.action_space.shape or env.action_space.n
+    assert isinstance(env.observation_space, Box)
+    assert isinstance(env.action_space, Box)
+    state_shape = env.observation_space.shape
+    action_shape = env.action_space.shape
     max_action = env.action_space.high[0]
     log.info(f"Observations shape: {state_shape}")
     log.info(f"Actions shape: {action_shape}")

--- a/examples/mujoco/mujoco_npg.py
+++ b/examples/mujoco/mujoco_npg.py
@@ -7,7 +7,6 @@ from typing import Literal
 
 import numpy as np
 import torch
-from mujoco_env import make_mujoco_env
 from sensai.util import logging
 from torch import nn
 from torch.distributions import Distribution, Independent, Normal
@@ -17,6 +16,7 @@ from tianshou.algorithm.algorithm_base import Algorithm
 from tianshou.algorithm.modelfree.reinforce import ProbabilisticActorPolicy
 from tianshou.algorithm.optim import AdamOptimizerFactory, LRSchedulerFactoryLinear
 from tianshou.data import Collector, CollectStats, ReplayBuffer, VectorReplayBuffer
+from tianshou.env.mujoco import make_mujoco_env
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OnPolicyTrainerParams
 from tianshou.utils.net.common import Net

--- a/examples/mujoco/mujoco_npg_hl.py
+++ b/examples/mujoco/mujoco_npg_hl.py
@@ -6,7 +6,7 @@ from typing import Literal
 import torch
 from sensai.util import logging
 
-from examples.mujoco.mujoco_env import MujocoEnvFactory
+from tianshou.env.mujoco import MujocoEnvFactory
 from tianshou.highlevel.config import OnPolicyTrainingConfig
 from tianshou.highlevel.experiment import (
     ExperimentConfig,

--- a/examples/mujoco/mujoco_ppo.py
+++ b/examples/mujoco/mujoco_ppo.py
@@ -7,7 +7,6 @@ from typing import Literal
 
 import numpy as np
 import torch
-from mujoco_env import make_mujoco_env
 from sensai.util import logging
 from torch import nn
 from torch.distributions import Distribution, Independent, Normal
@@ -17,6 +16,7 @@ from tianshou.algorithm.algorithm_base import Algorithm
 from tianshou.algorithm.modelfree.reinforce import ProbabilisticActorPolicy
 from tianshou.algorithm.optim import AdamOptimizerFactory, LRSchedulerFactoryLinear
 from tianshou.data import Collector, CollectStats, ReplayBuffer, VectorReplayBuffer
+from tianshou.env.mujoco import make_mujoco_env
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OnPolicyTrainerParams
 from tianshou.utils.net.common import ActorCritic, Net

--- a/examples/mujoco/mujoco_ppo.py
+++ b/examples/mujoco/mujoco_ppo.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 import numpy as np
 import torch
+from gymnasium.spaces import Box
 from sensai.util import logging
 from torch import nn
 from torch.distributions import Distribution, Independent, Normal
@@ -77,8 +78,10 @@ def main(
         num_test_envs,
         obs_norm=True,
     )
-    state_shape = env.observation_space.shape or env.observation_space.n
-    action_shape = env.action_space.shape or env.action_space.n
+    assert isinstance(env.observation_space, Box)
+    assert isinstance(env.action_space, Box)
+    state_shape = env.observation_space.shape
+    action_shape = env.action_space.shape
     max_action = env.action_space.high[0]
     log.info(f"Observations shape: {state_shape}")
     log.info(f"Actions shape: {action_shape}")

--- a/examples/mujoco/mujoco_ppo_hl.py
+++ b/examples/mujoco/mujoco_ppo_hl.py
@@ -6,7 +6,7 @@ from typing import Literal
 import torch
 from sensai.util import logging
 
-from examples.mujoco.mujoco_env import MujocoEnvFactory
+from tianshou.env.mujoco import MujocoEnvFactory
 from tianshou.highlevel.config import OnPolicyTrainingConfig
 from tianshou.highlevel.experiment import (
     ExperimentConfig,

--- a/examples/mujoco/mujoco_redq.py
+++ b/examples/mujoco/mujoco_redq.py
@@ -7,7 +7,6 @@ from typing import Literal
 
 import numpy as np
 import torch
-from mujoco_env import make_mujoco_env
 from sensai.util import logging
 
 from tianshou.algorithm import REDQ
@@ -16,6 +15,7 @@ from tianshou.algorithm.modelfree.redq import REDQPolicy
 from tianshou.algorithm.modelfree.sac import AutoAlpha
 from tianshou.algorithm.optim import AdamOptimizerFactory
 from tianshou.data import Collector, CollectStats, ReplayBuffer, VectorReplayBuffer
+from tianshou.env.mujoco import make_mujoco_env
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OffPolicyTrainerParams
 from tianshou.utils.net.common import EnsembleLinear, Net

--- a/examples/mujoco/mujoco_redq.py
+++ b/examples/mujoco/mujoco_redq.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 import numpy as np
 import torch
+from gymnasium.spaces import Box
 from sensai.util import logging
 
 from tianshou.algorithm import REDQ
@@ -74,8 +75,10 @@ def main(
         num_test_envs,
         obs_norm=False,
     )
-    state_shape = env.observation_space.shape or env.observation_space.n
-    action_shape = env.action_space.shape or env.action_space.n
+    assert isinstance(env.observation_space, Box)
+    assert isinstance(env.action_space, Box)
+    state_shape = env.observation_space.shape
+    action_shape = env.action_space.shape
     max_action = env.action_space.high[0]
     log.info(f"Observations shape: {state_shape}")
     log.info(f"Actions shape: {action_shape}")

--- a/examples/mujoco/mujoco_redq_hl.py
+++ b/examples/mujoco/mujoco_redq_hl.py
@@ -5,7 +5,7 @@ from typing import Literal
 
 from sensai.util import logging
 
-from examples.mujoco.mujoco_env import MujocoEnvFactory
+from tianshou.env.mujoco import MujocoEnvFactory
 from tianshou.highlevel.config import OffPolicyTrainingConfig
 from tianshou.highlevel.experiment import (
     ExperimentConfig,

--- a/examples/mujoco/mujoco_reinforce.py
+++ b/examples/mujoco/mujoco_reinforce.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 import numpy as np
 import torch
+from gymnasium.spaces import Box
 from sensai.util import logging
 from torch import nn
 from torch.distributions import Distribution, Independent, Normal
@@ -68,8 +69,10 @@ def main(
         num_test_envs,
         obs_norm=True,
     )
-    state_shape = env.observation_space.shape or env.observation_space.n
-    action_shape = env.action_space.shape or env.action_space.n
+    assert isinstance(env.observation_space, Box)
+    assert isinstance(env.action_space, Box)
+    state_shape = env.observation_space.shape
+    action_shape = env.action_space.shape
     max_action = env.action_space.high[0]
     log.info(f"Observations shape: {state_shape}")
     log.info(f"Actions shape: {action_shape}")

--- a/examples/mujoco/mujoco_reinforce.py
+++ b/examples/mujoco/mujoco_reinforce.py
@@ -7,7 +7,6 @@ from typing import Literal
 
 import numpy as np
 import torch
-from mujoco_env import make_mujoco_env
 from sensai.util import logging
 from torch import nn
 from torch.distributions import Distribution, Independent, Normal
@@ -17,6 +16,7 @@ from tianshou.algorithm.algorithm_base import Algorithm
 from tianshou.algorithm.modelfree.reinforce import ProbabilisticActorPolicy
 from tianshou.algorithm.optim import AdamOptimizerFactory, LRSchedulerFactoryLinear
 from tianshou.data import Collector, CollectStats, ReplayBuffer, VectorReplayBuffer
+from tianshou.env.mujoco import make_mujoco_env
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OnPolicyTrainerParams
 from tianshou.utils.net.common import Net

--- a/examples/mujoco/mujoco_reinforce_hl.py
+++ b/examples/mujoco/mujoco_reinforce_hl.py
@@ -6,7 +6,7 @@ from typing import Literal
 import torch
 from sensai.util import logging
 
-from examples.mujoco.mujoco_env import MujocoEnvFactory
+from tianshou.env.mujoco import MujocoEnvFactory
 from tianshou.highlevel.config import OnPolicyTrainingConfig
 from tianshou.highlevel.experiment import (
     ExperimentConfig,

--- a/examples/mujoco/mujoco_sac.py
+++ b/examples/mujoco/mujoco_sac.py
@@ -6,7 +6,6 @@ import pprint
 
 import numpy as np
 import torch
-from mujoco_env import make_mujoco_env
 from sensai.util import logging
 
 from tianshou.algorithm import SAC
@@ -14,6 +13,7 @@ from tianshou.algorithm.algorithm_base import Algorithm
 from tianshou.algorithm.modelfree.sac import AutoAlpha, SACPolicy
 from tianshou.algorithm.optim import AdamOptimizerFactory
 from tianshou.data import Collector, CollectStats, ReplayBuffer, VectorReplayBuffer
+from tianshou.env.mujoco import make_mujoco_env
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OffPolicyTrainerParams
 from tianshou.utils.net.common import Net

--- a/examples/mujoco/mujoco_sac.py
+++ b/examples/mujoco/mujoco_sac.py
@@ -6,6 +6,7 @@ import pprint
 
 import numpy as np
 import torch
+from gymnasium.spaces import Box
 from sensai.util import logging
 
 from tianshou.algorithm import SAC
@@ -69,8 +70,10 @@ def main(
         num_test_envs,
         obs_norm=False,
     )
-    state_shape = env.observation_space.shape or env.observation_space.n
-    action_shape = env.action_space.shape or env.action_space.n
+    assert isinstance(env.observation_space, Box)
+    assert isinstance(env.action_space, Box)
+    state_shape = env.observation_space.shape
+    action_shape = env.action_space.shape
     max_action = env.action_space.high[0]
     log.info(f"Observations shape: {state_shape}")
     log.info(f"Actions shape: {action_shape}")

--- a/examples/mujoco/mujoco_sac_hl.py
+++ b/examples/mujoco/mujoco_sac_hl.py
@@ -5,7 +5,7 @@ from typing import Literal
 
 from sensai.util import logging
 
-from examples.mujoco.mujoco_env import MujocoEnvFactory
+from tianshou.env.mujoco import MujocoEnvFactory
 from tianshou.highlevel.config import OffPolicyTrainingConfig
 from tianshou.highlevel.experiment import (
     ExperimentConfig,

--- a/examples/mujoco/mujoco_td3.py
+++ b/examples/mujoco/mujoco_td3.py
@@ -6,7 +6,6 @@ import pprint
 
 import numpy as np
 import torch
-from mujoco_env import make_mujoco_env
 from sensai.util import logging
 
 from tianshou.algorithm import TD3
@@ -14,6 +13,7 @@ from tianshou.algorithm.algorithm_base import Algorithm
 from tianshou.algorithm.modelfree.ddpg import ContinuousDeterministicPolicy
 from tianshou.algorithm.optim import AdamOptimizerFactory
 from tianshou.data import Collector, CollectStats, ReplayBuffer, VectorReplayBuffer
+from tianshou.env.mujoco import make_mujoco_env
 from tianshou.exploration import GaussianNoise
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OffPolicyTrainerParams

--- a/examples/mujoco/mujoco_td3.py
+++ b/examples/mujoco/mujoco_td3.py
@@ -6,6 +6,7 @@ import pprint
 
 import numpy as np
 import torch
+from gymnasium.spaces import Box
 from sensai.util import logging
 
 from tianshou.algorithm import TD3
@@ -70,8 +71,10 @@ def main(
         num_test_envs,
         obs_norm=False,
     )
-    state_shape = env.observation_space.shape or env.observation_space.n
-    action_shape = env.action_space.shape or env.action_space.n
+    assert isinstance(env.observation_space, Box)
+    assert isinstance(env.action_space, Box)
+    state_shape = env.observation_space.shape
+    action_shape = env.action_space.shape
     max_action = env.action_space.high[0]
     exploration_noise = exploration_noise * max_action
     policy_noise = policy_noise * max_action

--- a/examples/mujoco/mujoco_td3_hl.py
+++ b/examples/mujoco/mujoco_td3_hl.py
@@ -6,7 +6,7 @@ from typing import Literal
 import torch
 from sensai.util import logging
 
-from examples.mujoco.mujoco_env import MujocoEnvFactory
+from tianshou.env.mujoco import MujocoEnvFactory
 from tianshou.highlevel.config import OffPolicyTrainingConfig
 from tianshou.highlevel.experiment import (
     ExperimentConfig,

--- a/examples/mujoco/mujoco_trpo.py
+++ b/examples/mujoco/mujoco_trpo.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 import numpy as np
 import torch
+from gymnasium.spaces import Box
 from sensai.util import logging
 from torch import nn
 from torch.distributions import Distribution, Independent, Normal
@@ -74,8 +75,10 @@ def main(
         num_test_envs,
         obs_norm=True,
     )
-    state_shape = env.observation_space.shape or env.observation_space.n
-    action_shape = env.action_space.shape or env.action_space.n
+    assert isinstance(env.observation_space, Box)
+    assert isinstance(env.action_space, Box)
+    state_shape = env.observation_space.shape
+    action_shape = env.action_space.shape
     log.info(f"Observations shape: {state_shape}")
     log.info(f"Actions shape: {action_shape}")
     log.info(f"Action range: {np.min(env.action_space.low)}, {np.max(env.action_space.high)}")

--- a/examples/mujoco/mujoco_trpo.py
+++ b/examples/mujoco/mujoco_trpo.py
@@ -7,7 +7,6 @@ from typing import Literal
 
 import numpy as np
 import torch
-from mujoco_env import make_mujoco_env
 from sensai.util import logging
 from torch import nn
 from torch.distributions import Distribution, Independent, Normal
@@ -17,6 +16,7 @@ from tianshou.algorithm.algorithm_base import Algorithm
 from tianshou.algorithm.modelfree.reinforce import ProbabilisticActorPolicy
 from tianshou.algorithm.optim import AdamOptimizerFactory, LRSchedulerFactoryLinear
 from tianshou.data import Collector, CollectStats, ReplayBuffer, VectorReplayBuffer
+from tianshou.env.mujoco import make_mujoco_env
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OnPolicyTrainerParams
 from tianshou.utils.net.common import Net

--- a/examples/mujoco/mujoco_trpo_hl.py
+++ b/examples/mujoco/mujoco_trpo_hl.py
@@ -6,7 +6,7 @@ from typing import Literal
 import torch
 from sensai.util import logging
 
-from examples.mujoco.mujoco_env import MujocoEnvFactory
+from tianshou.env.mujoco import MujocoEnvFactory
 from tianshou.highlevel.config import OnPolicyTrainingConfig
 from tianshou.highlevel.experiment import (
     ExperimentConfig,

--- a/examples/offline/atari_bcq.py
+++ b/examples/offline/atari_bcq.py
@@ -17,8 +17,7 @@ from tianshou.algorithm.algorithm_base import Algorithm
 from tianshou.algorithm.imitation.discrete_bcq import DiscreteBCQPolicy
 from tianshou.algorithm.optim import AdamOptimizerFactory
 from tianshou.data import Collector, CollectStats, VectorReplayBuffer
-from tianshou.env.atari.atari_network import DQNet
-from tianshou.env.atari.atari_wrapper import make_atari_env
+from tianshou.env.atari import DQNet, make_atari_env
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OfflineTrainerParams
 from tianshou.utils.net.discrete import DiscreteActor

--- a/examples/offline/atari_cql.py
+++ b/examples/offline/atari_cql.py
@@ -18,8 +18,7 @@ from tianshou.algorithm.algorithm_base import Algorithm
 from tianshou.algorithm.modelfree.qrdqn import QRDQNPolicy
 from tianshou.algorithm.optim import AdamOptimizerFactory
 from tianshou.data import Collector, CollectStats, VectorReplayBuffer
-from tianshou.env.atari.atari_network import QRDQNet
-from tianshou.env.atari.atari_wrapper import make_atari_env
+from tianshou.env.atari import QRDQNet, make_atari_env
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OfflineTrainerParams
 from tianshou.utils.space_info import SpaceInfo

--- a/examples/offline/atari_crr.py
+++ b/examples/offline/atari_crr.py
@@ -17,8 +17,7 @@ from tianshou.algorithm.algorithm_base import Algorithm
 from tianshou.algorithm.modelfree.reinforce import DiscreteActorPolicy
 from tianshou.algorithm.optim import AdamOptimizerFactory
 from tianshou.data import Collector, CollectStats, VectorReplayBuffer
-from tianshou.env.atari.atari_network import DQNet
-from tianshou.env.atari.atari_wrapper import make_atari_env
+from tianshou.env.atari import DQNet, make_atari_env
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OfflineTrainerParams
 from tianshou.utils.net.discrete import DiscreteActor, DiscreteCritic

--- a/examples/offline/atari_il.py
+++ b/examples/offline/atari_il.py
@@ -18,8 +18,7 @@ from tianshou.algorithm.imitation.imitation_base import (
 )
 from tianshou.algorithm.optim import AdamOptimizerFactory
 from tianshou.data import Collector, CollectStats, VectorReplayBuffer
-from tianshou.env.atari.atari_network import DQNet
-from tianshou.env.atari.atari_wrapper import make_atari_env
+from tianshou.env.atari import DQNet, make_atari_env
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OfflineTrainerParams
 from tianshou.utils.space_info import SpaceInfo

--- a/examples/vizdoom/vizdoom_c51.py
+++ b/examples/vizdoom/vizdoom_c51.py
@@ -13,7 +13,7 @@ from tianshou.algorithm.algorithm_base import Algorithm
 from tianshou.algorithm.modelfree.c51 import C51Policy
 from tianshou.algorithm.optim import AdamOptimizerFactory
 from tianshou.data import Collector, CollectStats, VectorReplayBuffer
-from tianshou.env.atari.atari_network import C51Net
+from tianshou.env.atari import C51Net
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OffPolicyTrainerParams
 

--- a/examples/vizdoom/vizdoom_ppo.py
+++ b/examples/vizdoom/vizdoom_ppo.py
@@ -15,7 +15,7 @@ from tianshou.algorithm.modelbased.icm import ICMOnPolicyWrapper
 from tianshou.algorithm.modelfree.reinforce import ProbabilisticActorPolicy
 from tianshou.algorithm.optim import AdamOptimizerFactory, LRSchedulerFactoryLinear
 from tianshou.data import Collector, CollectStats, VectorReplayBuffer
-from tianshou.env.atari.atari_network import DQNet
+from tianshou.env.atari import DQNet
 from tianshou.highlevel.logger import LoggerFactoryDefault
 from tianshou.trainer import OnPolicyTrainerParams
 from tianshou.utils.net.discrete import (

--- a/tianshou/env/atari/__init__.py
+++ b/tianshou/env/atari/__init__.py
@@ -1,4 +1,10 @@
-"""Atari environment helpers for Tianshou."""
+"""Atari environment helpers for Tianshou.
+
+Network classes (C51Net, DQNet, etc.) are always importable.
+Wrapper classes (WarpFrame, make_atari_env, etc.) require optional
+dependencies (cv2/gymnasium[atari]) and are imported lazily to avoid
+breaking environments that only need the network utilities.
+"""
 
 from tianshou.env.atari.atari_network import (
     ActorFactoryAtariDQN,
@@ -11,20 +17,22 @@ from tianshou.env.atari.atari_network import (
     ScaledObsInputActionReprNet,
     layer_init,
 )
-from tianshou.env.atari.atari_wrapper import (
-    AtariEnvFactory,
-    AtariEpochStopCallback,
-    ClipRewardEnv,
-    EpisodicLifeEnv,
-    FireResetEnv,
-    FrameStack,
-    MaxAndSkipEnv,
-    NoopResetEnv,
-    ScaledFloatFrame,
-    WarpFrame,
-    make_atari_env,
-    wrap_deepmind,
-)
+
+# Wrapper symbols that require cv2 — imported lazily via __getattr__
+_WRAPPER_SYMBOLS = {
+    "AtariEnvFactory",
+    "AtariEpochStopCallback",
+    "ClipRewardEnv",
+    "EpisodicLifeEnv",
+    "FireResetEnv",
+    "FrameStack",
+    "MaxAndSkipEnv",
+    "NoopResetEnv",
+    "ScaledFloatFrame",
+    "WarpFrame",
+    "make_atari_env",
+    "wrap_deepmind",
+}
 
 __all__ = [
     "ActorFactoryAtariDQN",
@@ -49,3 +57,11 @@ __all__ = [
     "make_atari_env",
     "wrap_deepmind",
 ]
+
+
+def __getattr__(name: str):
+    if name in _WRAPPER_SYMBOLS:
+        from tianshou.env.atari import atari_wrapper
+
+        return getattr(atari_wrapper, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tianshou/env/atari/__init__.py
+++ b/tianshou/env/atari/__init__.py
@@ -1,0 +1,51 @@
+"""Atari environment helpers for Tianshou."""
+
+from tianshou.env.atari.atari_network import (
+    ActorFactoryAtariDQN,
+    C51Net,
+    DQNet,
+    IntermediateModuleFactoryAtariDQN,
+    IntermediateModuleFactoryAtariDQNFeatures,
+    QRDQNet,
+    RainbowNet,
+    ScaledObsInputActionReprNet,
+    layer_init,
+)
+from tianshou.env.atari.atari_wrapper import (
+    AtariEnvFactory,
+    AtariEpochStopCallback,
+    ClipRewardEnv,
+    EpisodicLifeEnv,
+    FireResetEnv,
+    FrameStack,
+    MaxAndSkipEnv,
+    NoopResetEnv,
+    ScaledFloatFrame,
+    WarpFrame,
+    make_atari_env,
+    wrap_deepmind,
+)
+
+__all__ = [
+    "ActorFactoryAtariDQN",
+    "AtariEnvFactory",
+    "AtariEpochStopCallback",
+    "C51Net",
+    "ClipRewardEnv",
+    "DQNet",
+    "EpisodicLifeEnv",
+    "FireResetEnv",
+    "FrameStack",
+    "IntermediateModuleFactoryAtariDQN",
+    "IntermediateModuleFactoryAtariDQNFeatures",
+    "MaxAndSkipEnv",
+    "NoopResetEnv",
+    "QRDQNet",
+    "RainbowNet",
+    "ScaledFloatFrame",
+    "ScaledObsInputActionReprNet",
+    "WarpFrame",
+    "layer_init",
+    "make_atari_env",
+    "wrap_deepmind",
+]

--- a/tianshou/env/mujoco/__init__.py
+++ b/tianshou/env/mujoco/__init__.py
@@ -1,0 +1,13 @@
+"""Mujoco environment helpers for Tianshou."""
+
+from tianshou.env.mujoco.mujoco_env import (
+    MujocoEnvFactory,
+    MujocoEnvObsRmsPersistence,
+    make_mujoco_env,
+)
+
+__all__ = [
+    "MujocoEnvFactory",
+    "MujocoEnvObsRmsPersistence",
+    "make_mujoco_env",
+]

--- a/tianshou/env/mujoco/mujoco_env.py
+++ b/tianshou/env/mujoco/mujoco_env.py
@@ -1,0 +1,109 @@
+import logging
+import pickle
+
+from gymnasium import Env
+
+from tianshou.env import BaseVectorEnv, VectorEnvNormObs
+from tianshou.highlevel.env import (
+    ContinuousEnvironments,
+    EnvFactoryRegistered,
+    EnvMode,
+    EnvPoolFactory,
+    VectorEnvType,
+)
+from tianshou.highlevel.persistence import Persistence, PersistEvent, RestoreEvent
+from tianshou.highlevel.world import World
+
+envpool_is_available = True
+try:
+    import envpool
+except ImportError:
+    envpool_is_available = False
+    envpool = None
+
+log = logging.getLogger(__name__)
+
+
+def make_mujoco_env(
+    task: str,
+    seed: int,
+    num_training_envs: int,
+    num_test_envs: int,
+    obs_norm: bool,
+) -> tuple[Env, BaseVectorEnv, BaseVectorEnv]:
+    """Wrapper function for Mujoco env.
+
+    If EnvPool is installed, it will automatically switch to EnvPool's Mujoco env.
+
+    :return: a tuple of (single env, training envs, test envs).
+    """
+    envs = MujocoEnvFactory(task, obs_norm=obs_norm).create_envs(
+        num_training_envs,
+        num_test_envs,
+        seed=seed,
+    )
+    return envs.env, envs.training_envs, envs.test_envs
+
+
+class MujocoEnvObsRmsPersistence(Persistence):
+    FILENAME = "env_obs_rms.pkl"
+
+    def persist(self, event: PersistEvent, world: World) -> None:
+        if event != PersistEvent.PERSIST_POLICY:
+            return  # type: ignore[unreachable]  # since PersistEvent has only one member, mypy infers that line is unreachable
+        obs_rms = world.envs.training_envs.get_obs_rms()
+        path = world.persist_path(self.FILENAME)
+        log.info(f"Saving environment obs_rms value to {path}")
+        with open(path, "wb") as f:
+            pickle.dump(obs_rms, f)
+
+    def restore(self, event: RestoreEvent, world: World) -> None:
+        if event != RestoreEvent.RESTORE_POLICY:
+            return  # type: ignore[unreachable]
+        path = world.restore_path(self.FILENAME)
+        log.info(f"Restoring environment obs_rms value from {path}")
+        with open(path, "rb") as f:
+            obs_rms = pickle.load(f)
+        world.envs.training_envs.set_obs_rms(obs_rms)
+        world.envs.test_envs.set_obs_rms(obs_rms)
+        if world.envs.watch_env is not None:
+            world.envs.watch_env.set_obs_rms(obs_rms)
+
+
+class MujocoEnvFactory(EnvFactoryRegistered):
+    def __init__(
+        self,
+        task: str,
+        obs_norm: bool = True,
+        venv_type: VectorEnvType = VectorEnvType.SUBPROC_SHARED_MEM_AUTO,
+    ) -> None:
+        super().__init__(
+            task=task,
+            venv_type=venv_type,
+            envpool_factory=EnvPoolFactory() if envpool_is_available else None,
+        )
+        self.obs_norm = obs_norm
+
+    def create_venv(self, num_envs: int, mode: EnvMode, seed: int | None = None) -> BaseVectorEnv:
+        env = super().create_venv(num_envs, mode, seed=seed)
+        # obs norm wrapper
+        if self.obs_norm:
+            env = VectorEnvNormObs(env, update_obs_rms=mode == EnvMode.TRAINING)
+        return env
+
+    def create_envs(
+        self,
+        num_training_envs: int,
+        num_test_envs: int,
+        create_watch_env: bool = False,
+        seed: int | None = None,
+    ) -> ContinuousEnvironments:
+        envs = super().create_envs(num_training_envs, num_test_envs, create_watch_env, seed=seed)
+        assert isinstance(envs, ContinuousEnvironments)
+
+        if self.obs_norm:
+            envs.test_envs.set_obs_rms(envs.training_envs.get_obs_rms())
+            if envs.watch_env is not None:
+                envs.watch_env.set_obs_rms(envs.training_envs.get_obs_rms())
+            envs.set_persistence(MujocoEnvObsRmsPersistence())
+        return envs


### PR DESCRIPTION
## Summary

Addresses #988 — moves the mujoco helper code from `examples/` into the tianshou package and adds proper `__init__.py` files for both atari and mujoco submodules.

### Changes

**New files (3):**
- `tianshou/env/atari/__init__.py` — re-exports all public symbols from `atari_wrapper.py` and `atari_network.py`
- `tianshou/env/mujoco/__init__.py` — exports `make_mujoco_env`, `MujocoEnvFactory`, `MujocoEnvObsRmsPersistence`
- `tianshou/env/mujoco/mujoco_env.py` — moved from `examples/mujoco/mujoco_env.py`

**Modified files (37):**
- 18 mujoco examples: `from mujoco_env import ...` → `from tianshou.env.mujoco import ...`
- 12 atari + 4 offline + 2 vizdoom examples: `from tianshou.env.atari.atari_wrapper import ...` → `from tianshou.env.atari import ...`
- `examples/mujoco/mujoco_env.py`: converted to backward-compatible re-export shim

**Not modified:**
- `tianshou/env/__init__.py` — atari/mujoco have optional deps (cv2, mujoco), not auto-imported

<details>
<summary>Before (master branch)</summary>

```
$ python -m pytest test/base/ -x --tb=short -q
149 passed, 3 skipped, 91 warnings in 49.93s
```

</details>

<details>
<summary>After (this branch)</summary>

```
$ python -m pytest test/base/ -x --tb=short -q
149 passed, 3 skipped, 91 warnings in 48.95s

$ python -c "from tianshou.env.mujoco import make_mujoco_env; print('OK')"
OK
$ python -c "from examples.mujoco.mujoco_env import make_mujoco_env; print('backward compat OK')"
backward compat OK
```

</details>

## Test plan
- [x] `pytest test/base/ -x` — 149 passed, 3 skipped (identical to master)
- [x] Import from new location works
- [x] Backward-compatible import works
- [x] `ruff check` and `ruff format --check` pass

Closes #988