### PR TITLE
Add EnvPoolVectorEnv wrapper for proper envpool integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+**New features:**
+* `env`:
+  * Add `EnvPoolVectorEnv` wrapper for proper envpool integration, replacing inline info-conversion hacks in `Collector` #1294
+
 # Release 2.0.1 (2026-04-02)
 
 This is a maintenance release.

--- a/test/base/test_collector.py
+++ b/test/base/test_collector.py
@@ -26,7 +26,7 @@ from tianshou.data.collector import (
     StepHook,
 )
 from tianshou.data.types import ObsBatchProtocol, RolloutBatchProtocol
-from tianshou.env import DummyVectorEnv, SubprocVectorEnv
+from tianshou.env import DummyVectorEnv, EnvPoolVectorEnv, SubprocVectorEnv
 
 try:
     import envpool
@@ -939,6 +939,72 @@ def test_collector_envpool_gym_reset_return_info() -> None:
     env_ids = np.zeros(len(envs) * 10)
     env_ids[[0, 1, 10, 11, 20, 21, 30, 31]] = [0, 0, 1, 1, 2, 2, 3, 3]
     assert np.allclose(c0.buffer.info["env_id"], env_ids)
+
+
+class _MockEnvPoolEnv:
+    """Mock envpool env that returns dict-of-arrays info (envpool convention)."""
+
+    def __init__(self, num_envs: int = 4) -> None:
+        self._num_envs = num_envs
+        self._step_count = np.zeros(num_envs, dtype=np.int32)
+        self._max_steps = 5
+        self.action_space = gym.spaces.Discrete(2)
+        self.observation_space = gym.spaces.Box(low=0.0, high=1.0, shape=(3,))
+        self.config = {"num_envs": num_envs}
+
+    def __len__(self) -> int:
+        return self._num_envs
+
+    def reset(self, **kwargs: Any) -> tuple[np.ndarray, dict]:
+        if "env_id" in kwargs:
+            ids = np.atleast_1d(kwargs["env_id"])
+            self._step_count[ids] = 0
+            n = len(ids)
+        else:
+            self._step_count[:] = 0
+            n = self._num_envs
+        obs = np.random.rand(n, 3).astype(np.float32)
+        info: dict[str, Any] = {
+            "env_id": np.arange(n),
+            "elapsed_step": np.zeros(n, dtype=np.int32),
+        }
+        return obs, info
+
+    def step(
+        self,
+        action: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict]:
+        n = len(action)
+        self._step_count[:n] += 1
+        obs = np.random.rand(n, 3).astype(np.float32)
+        rew = np.ones(n, dtype=np.float64)
+        terminated = self._step_count[:n] >= self._max_steps
+        truncated = np.zeros(n, dtype=bool)
+        info: dict[str, Any] = {
+            "env_id": np.arange(n),
+            "elapsed_step": self._step_count[:n].copy(),
+        }
+        return obs, rew, terminated, truncated, info
+
+    def close(self) -> None:
+        pass
+
+
+def test_collector_auto_wraps_envpool_env() -> None:
+    """Collector should auto-wrap envpool-like envs with EnvPoolVectorEnv."""
+    mock = _MockEnvPoolEnv(num_envs=2)
+    policy = MaxActionPolicy(action_space=mock.action_space)
+    collector = Collector[CollectStats](
+        policy,
+        mock,
+        VectorReplayBuffer(total_size=20, buffer_num=2),
+    )
+    # Verify that the env was wrapped
+    assert isinstance(collector.env, EnvPoolVectorEnv)
+
+    collector.reset()
+    result = collector.collect(n_step=4)
+    assert result.n_collected_steps >= 4
 
 
 def test_collector_with_vector_env() -> None:

--- a/test/base/test_collector.py
+++ b/test/base/test_collector.py
@@ -973,8 +973,21 @@ class _MockEnvPoolEnv:
     def step(
         self,
         action: np.ndarray,
-    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict[str, Any]]:
         n = len(action)
+        return self._make_step_result(n)
+
+    def send(self, action: np.ndarray, env_id: np.ndarray | None = None) -> None:
+        n = len(action) if env_id is None else len(env_id)
+        self._pending_n = n
+
+    def recv(self) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict[str, Any]]:
+        return self._make_step_result(self._pending_n)
+
+    def _make_step_result(
+        self,
+        n: int,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict[str, Any]]:
         self._step_count[:n] += 1
         obs = np.random.rand(n, 3).astype(np.float32)
         rew = np.ones(n, dtype=np.float64)
@@ -996,7 +1009,7 @@ def test_collector_auto_wraps_envpool_env() -> None:
     policy = MaxActionPolicy(action_space=mock.action_space)
     collector = Collector[CollectStats](
         policy,
-        mock,
+        mock,  # type: ignore[arg-type]
         VectorReplayBuffer(total_size=20, buffer_num=2),
     )
     # Verify that the env was wrapped

--- a/test/base/test_env.py
+++ b/test/base/test_env.py
@@ -256,7 +256,7 @@ def test_venv_wrapper_gym(num_envs: int = 4) -> None:
 
 
 def run_align_norm_obs(
-    raw_env: DummyVectorEnv,
+    raw_env: BaseVectorEnv,
     train_env: VectorEnvNormObs,
     test_env: VectorEnvNormObs,
     action_list: list[np.ndarray],
@@ -449,6 +449,18 @@ class _MockEnvPoolEnv:
         action: np.ndarray,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict]:
         n = len(action)
+        return self._make_step_result(n)
+
+    def send(self, action: np.ndarray, env_id: np.ndarray | None = None) -> None:
+        self._pending_n = len(action) if env_id is None else len(env_id)
+
+    def recv(self) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict]:
+        return self._make_step_result(self._pending_n)
+
+    def _make_step_result(
+        self,
+        n: int,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict]:
         obs = np.random.rand(n, self._obs_dim).astype(np.float32)
         rew = np.zeros(n)
         terminated = np.zeros(n, dtype=bool)
@@ -530,7 +542,7 @@ def test_envpool_vector_env_close() -> None:
     assert not env.is_closed
     env.close()
     assert env.is_closed
-    assert mock._closed
+    assert mock._closed  # type: ignore[unreachable]
 
 
 def test_envpool_vector_env_seed() -> None:

--- a/test/base/test_env.py
+++ b/test/base/test_env.py
@@ -13,6 +13,7 @@ from tianshou.data import Batch
 from tianshou.env import (
     ContinuousToDiscrete,
     DummyVectorEnv,
+    EnvPoolVectorEnv,
     MultiDiscreteToDiscrete,
     RayVectorEnv,
     ShmemVectorEnv,
@@ -394,7 +395,7 @@ def test_gym_wrappers() -> None:
 # TODO: old gym envs are no longer supported! Replace by Ant-v4 and fix assoticiated tests
 @pytest.mark.skipif(envpool is None, reason="EnvPool doesn't support this platform")
 def test_venv_wrapper_envpool() -> None:
-    raw = envpool.make_gymnasium("Ant-v3", num_envs=4)
+    raw = EnvPoolVectorEnv(envpool.make_gymnasium("Ant-v3", num_envs=4))
     train = VectorEnvNormObs(envpool.make_gymnasium("Ant-v3", num_envs=4))
     test = VectorEnvNormObs(envpool.make_gymnasium("Ant-v3", num_envs=4), update_obs_rms=False)
     test.set_obs_rms(train.get_obs_rms())
@@ -410,13 +411,138 @@ def test_venv_wrapper_envpool_gym_reset_return_info() -> None:
     )
     obs, info = env.reset()
     assert obs.shape[0] == num_envs
-    # This is not actually unreachable b/c envpool does not return info in the right format
-    if isinstance(info, dict):  # type: ignore[unreachable]
-        for _, v in info.items():  # type: ignore[unreachable]
-            if not isinstance(v, dict):
-                assert v.shape[0] == num_envs
-    else:
-        for _info in info:
-            for _, v in _info.items():
-                if not isinstance(v, dict):
-                    assert v.shape[0] == num_envs
+    # After wrapping with EnvPoolVectorEnv, info should be an array of dicts
+    assert isinstance(info, np.ndarray)
+    assert len(info) == num_envs
+    for _info in info:
+        assert isinstance(_info, dict)
+
+
+class _MockEnvPoolEnv:
+    """Mock that mimics the envpool gymnasium interface (dict-of-arrays info format)."""
+
+    def __init__(self, num_envs: int = 4, obs_dim: int = 3) -> None:
+        self._num_envs = num_envs
+        self._obs_dim = obs_dim
+        self.action_space = gym.spaces.Discrete(2)
+        self.observation_space = gym.spaces.Box(low=0.0, high=1.0, shape=(obs_dim,))
+        self.config = {"num_envs": num_envs}
+        self._closed = False
+
+    def __len__(self) -> int:
+        return self._num_envs
+
+    def reset(self, **kwargs: Any) -> tuple[np.ndarray, dict]:
+        n = self._num_envs
+        if "env_id" in kwargs:
+            n = len(np.atleast_1d(kwargs["env_id"]))
+        obs = np.random.rand(n, self._obs_dim).astype(np.float32)
+        # envpool returns info as dict-of-arrays
+        info: dict = {
+            "env_id": np.arange(n),
+            "elapsed_step": np.zeros(n, dtype=np.int32),
+        }
+        return obs, info
+
+    def step(
+        self,
+        action: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict]:
+        n = len(action)
+        obs = np.random.rand(n, self._obs_dim).astype(np.float32)
+        rew = np.zeros(n)
+        terminated = np.zeros(n, dtype=bool)
+        truncated = np.zeros(n, dtype=bool)
+        # envpool returns info as dict-of-arrays
+        info: dict = {
+            "env_id": np.arange(n),
+            "elapsed_step": np.ones(n, dtype=np.int32),
+        }
+        return obs, rew, terminated, truncated, info
+
+    def close(self) -> None:
+        self._closed = True
+
+
+def test_envpool_vector_env_reset_converts_info_format() -> None:
+    """EnvPoolVectorEnv should convert dict-of-arrays info to array-of-dicts."""
+    mock = _MockEnvPoolEnv(num_envs=3, obs_dim=2)
+    env = EnvPoolVectorEnv(mock)
+
+    assert len(env) == 3
+
+    obs, info = env.reset()
+    assert obs.shape == (3, 2)
+    # info must be an array of dicts, not a dict of arrays
+    assert isinstance(info, np.ndarray)
+    assert len(info) == 3
+    for d in info:
+        assert isinstance(d, dict)
+        assert "env_id" in d
+        assert "elapsed_step" in d
+
+
+def test_envpool_vector_env_step_converts_info_format() -> None:
+    """EnvPoolVectorEnv.step should convert info and inject env_id."""
+    mock = _MockEnvPoolEnv(num_envs=4, obs_dim=5)
+    env = EnvPoolVectorEnv(mock)
+
+    action = np.array([0, 1, 0, 1])
+    obs, rew, terminated, truncated, info = env.step(action)
+
+    assert obs.shape == (4, 5)
+    assert len(info) == 4
+    for i, d in enumerate(info):
+        assert isinstance(d, dict)
+        # env_id should be injected by the wrapper
+        assert "env_id" in d
+        assert d["env_id"] == i
+
+
+def test_envpool_vector_env_step_with_subset_ids() -> None:
+    """EnvPoolVectorEnv.step with explicit id should set correct env_ids in info."""
+    mock = _MockEnvPoolEnv(num_envs=4, obs_dim=2)
+    env = EnvPoolVectorEnv(mock)
+
+    action = np.array([1, 0])
+    obs, rew, terminated, truncated, info = env.step(action, id=[1, 3])
+
+    # The env_id in info should match the requested ids
+    assert info[0]["env_id"] == 1
+    assert info[1]["env_id"] == 3
+
+
+def test_envpool_vector_env_partial_reset() -> None:
+    """EnvPoolVectorEnv.reset with env_id should pass it through to the underlying env."""
+    mock = _MockEnvPoolEnv(num_envs=4, obs_dim=3)
+    env = EnvPoolVectorEnv(mock)
+
+    obs, info = env.reset(env_id=[0, 2])
+    assert obs.shape[0] == 2
+    assert len(info) == 2
+
+
+def test_envpool_vector_env_close() -> None:
+    """EnvPoolVectorEnv.close should close the underlying env."""
+    mock = _MockEnvPoolEnv(num_envs=2)
+    env = EnvPoolVectorEnv(mock)
+
+    assert not env.is_closed
+    env.close()
+    assert env.is_closed
+    assert mock._closed
+
+
+def test_envpool_vector_env_seed() -> None:
+    """EnvPoolVectorEnv.seed should not raise."""
+    mock = _MockEnvPoolEnv(num_envs=3)
+    env = EnvPoolVectorEnv(mock)
+
+    result = env.seed(42)
+    assert len(result) == 3
+
+    result = env.seed([1, 2, 3])
+    assert len(result) == 3
+
+    result = env.seed(None)
+    assert len(result) == 3

--- a/test/base/test_env.py
+++ b/test/base/test_env.py
@@ -256,7 +256,7 @@ def test_venv_wrapper_gym(num_envs: int = 4) -> None:
 
 
 def run_align_norm_obs(
-    raw_env: BaseVectorEnv,
+    raw_env: BaseVectorEnv | EnvPoolVectorEnv,
     train_env: VectorEnvNormObs,
     test_env: VectorEnvNormObs,
     action_list: list[np.ndarray],

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -33,6 +33,7 @@ from tianshou.data.types import (
     RolloutBatchProtocol,
 )
 from tianshou.env import BaseVectorEnv, DummyVectorEnv, EnvPoolVectorEnv
+from tianshou.env.venvs import _is_envpool_env
 from tianshou.utils.determinism import TraceLogger
 from tianshou.utils.print import DataclassPPrintMixin
 from tianshou.utils.torch_utils import torch_train_mode
@@ -345,10 +346,11 @@ class BaseCollector(Generic[TCollectStats], ABC):
             warnings.warn("Single environment detected, wrap to DummyVectorEnv.")
             # Unfortunately, mypy seems to ignore the isinstance in lambda, maybe a bug in mypy
             env = DummyVectorEnv([lambda: env])  # type: ignore
-        elif not isinstance(env, BaseVectorEnv) and hasattr(env, "__len__"):
-            # Wrap envpool (or similar) environments that have __len__ but are
-            # not BaseVectorEnv instances.  EnvPoolVectorEnv normalises the
-            # info format so that downstream code does not need special-casing.
+        elif not isinstance(env, BaseVectorEnv) and _is_envpool_env(env):
+            # Wrap envpool environments that expose a config dict with
+            # "num_envs" and send/recv methods.  EnvPoolVectorEnv normalises
+            # the info format so that downstream code does not need
+            # special-casing.
             env = EnvPoolVectorEnv(env)  # type: ignore[assignment]
 
         if buffer is None:

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -349,7 +349,7 @@ class BaseCollector(Generic[TCollectStats], ABC):
             # Wrap envpool (or similar) environments that have __len__ but are
             # not BaseVectorEnv instances.  EnvPoolVectorEnv normalises the
             # info format so that downstream code does not need special-casing.
-            env = EnvPoolVectorEnv(env)
+            env = EnvPoolVectorEnv(env)  # type: ignore[assignment]
 
         if buffer is None:
             buffer = VectorReplayBuffer(DEFAULT_BUFFER_MAXSIZE * len(env), len(env))

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -32,7 +32,7 @@ from tianshou.data.types import (
     ObsBatchProtocol,
     RolloutBatchProtocol,
 )
-from tianshou.env import BaseVectorEnv, DummyVectorEnv
+from tianshou.env import BaseVectorEnv, DummyVectorEnv, EnvPoolVectorEnv
 from tianshou.utils.determinism import TraceLogger
 from tianshou.utils.print import DataclassPPrintMixin
 from tianshou.utils.torch_utils import torch_train_mode
@@ -264,12 +264,6 @@ def _nullable_slice(obj: _TArrLike, indices: np.ndarray) -> _TArrLike:
     return None  # type: ignore[unreachable]
 
 
-def _dict_of_arr_to_arr_of_dicts(
-    dict_of_arr: dict[str, np.ndarray | dict],
-) -> np.ndarray:
-    return np.array(Batch(dict_of_arr).to_list_of_dicts())
-
-
 def _HACKY_create_info_batch(info_array: np.ndarray) -> Batch:
     """TODO: this exists because of multiple bugs in Batch and to restore backwards compatibility.
     Batch should be fixed and this function should be removed asap!.
@@ -351,6 +345,11 @@ class BaseCollector(Generic[TCollectStats], ABC):
             warnings.warn("Single environment detected, wrap to DummyVectorEnv.")
             # Unfortunately, mypy seems to ignore the isinstance in lambda, maybe a bug in mypy
             env = DummyVectorEnv([lambda: env])  # type: ignore
+        elif not isinstance(env, BaseVectorEnv) and hasattr(env, "__len__"):
+            # Wrap envpool (or similar) environments that have __len__ but are
+            # not BaseVectorEnv instances.  EnvPoolVectorEnv normalises the
+            # info format so that downstream code does not need special-casing.
+            env = EnvPoolVectorEnv(env)
 
         if buffer is None:
             buffer = VectorReplayBuffer(DEFAULT_BUFFER_MAXSIZE * len(env), len(env))
@@ -441,12 +440,6 @@ class BaseCollector(Generic[TCollectStats], ABC):
         """Reset the environments and the initial obs, info, and hidden state of the collector."""
         gym_reset_kwargs = gym_reset_kwargs or {}
         obs_NO, info_N = self.env.reset(**gym_reset_kwargs)
-        # TODO: hack, wrap envpool envs such that they don't return a dict
-        if isinstance(info_N, dict):  # type: ignore[unreachable]
-            # this can happen if the env is an envpool env. Then the thing returned by reset is a dict
-            # with array entries instead of an array of dicts
-            # We use Batch to turn it into an array of dicts
-            info_N = _dict_of_arr_to_arr_of_dicts(info_N)  # type: ignore[unreachable]
         return obs_NO, info_N
 
     @abstractmethod
@@ -718,8 +711,7 @@ class Collector(BaseCollector[TCollectStats], Generic[TCollectStats]):
                 act_normalized_RA = np.array(
                     [self._action_space[i].sample() for i in ready_env_ids_R],
                 )
-            # TODO: test whether envpool env explicitly
-            except TypeError:  # envpool's action space is not for per-env
+            except TypeError:
                 act_normalized_RA = np.array([self._action_space.sample() for _ in ready_env_ids_R])
             act_RA = self.policy.map_action_inverse(np.array(act_normalized_RA))
             policy_R = Batch()
@@ -879,9 +871,6 @@ class Collector(BaseCollector[TCollectStats], Generic[TCollectStats]):
                 collect_action_computation_batch_R.act_normalized,
                 ready_env_ids_R,
             )
-            if isinstance(info_R, dict):  # type: ignore[unreachable]
-                # This can happen if the env is an envpool env. Then the info returned by step is a dict
-                info_R = _dict_of_arr_to_arr_of_dicts(info_R)  # type: ignore[unreachable]
             done_R = np.logical_or(terminated_R, truncated_R)
 
             current_step_batch_R = cast(

--- a/tianshou/env/__init__.py
+++ b/tianshou/env/__init__.py
@@ -10,6 +10,7 @@ from tianshou.env.venv_wrappers import VectorEnvNormObs, VectorEnvWrapper
 from tianshou.env.venvs import (
     BaseVectorEnv,
     DummyVectorEnv,
+    EnvPoolVectorEnv,
     RayVectorEnv,
     ShmemVectorEnv,
     SubprocVectorEnv,
@@ -19,6 +20,7 @@ __all__ = [
     "BaseVectorEnv",
     "ContinuousToDiscrete",
     "DummyVectorEnv",
+    "EnvPoolVectorEnv",
     "MultiDiscreteToDiscrete",
     "PettingZooEnv",
     "RayVectorEnv",

--- a/tianshou/env/venv_wrappers.py
+++ b/tianshou/env/venv_wrappers.py
@@ -15,11 +15,11 @@ class VectorEnvWrapper(BaseVectorEnv):
     # It's not a "true" subclass of BaseVectorEnv but it does extend its interface, so
     # it can be used as a drop-in replacement
     # noinspection PyMissingConstructor
-    def __init__(self, venv: BaseVectorEnv) -> None:
+    def __init__(self, venv: BaseVectorEnv | Any) -> None:
         # Auto-wrap envpool envs so that callers can pass them directly.
         # At runtime `venv` may be a raw envpool env (not a BaseVectorEnv).
         if not isinstance(venv, BaseVectorEnv) and hasattr(venv, "__len__"):
-            venv = EnvPoolVectorEnv(venv)  # type: ignore[arg-type]
+            venv = EnvPoolVectorEnv(venv)
         self.venv = venv
         self.is_async = venv.is_async
 

--- a/tianshou/env/venv_wrappers.py
+++ b/tianshou/env/venv_wrappers.py
@@ -4,7 +4,7 @@ import numpy as np
 import torch
 
 from tianshou.env.utils import gym_new_venv_step_type
-from tianshou.env.venvs import GYM_RESERVED_KEYS, BaseVectorEnv, EnvPoolVectorEnv
+from tianshou.env.venvs import GYM_RESERVED_KEYS, BaseVectorEnv, EnvPoolVectorEnv, _is_envpool_env
 from tianshou.utils import RunningMeanStd
 
 
@@ -18,7 +18,7 @@ class VectorEnvWrapper(BaseVectorEnv):
     def __init__(self, venv: BaseVectorEnv | Any) -> None:
         # Auto-wrap envpool envs so that callers can pass them directly.
         # At runtime `venv` may be a raw envpool env (not a BaseVectorEnv).
-        if not isinstance(venv, BaseVectorEnv) and hasattr(venv, "__len__"):
+        if not isinstance(venv, BaseVectorEnv) and _is_envpool_env(venv):
             venv = EnvPoolVectorEnv(venv)
         self.venv = venv
         self.is_async = venv.is_async

--- a/tianshou/env/venv_wrappers.py
+++ b/tianshou/env/venv_wrappers.py
@@ -16,9 +16,10 @@ class VectorEnvWrapper(BaseVectorEnv):
     # it can be used as a drop-in replacement
     # noinspection PyMissingConstructor
     def __init__(self, venv: BaseVectorEnv) -> None:
-        # Auto-wrap envpool envs so that callers can pass them directly
-        if not isinstance(venv, (BaseVectorEnv, EnvPoolVectorEnv)) and hasattr(venv, "__len__"):
-            venv = EnvPoolVectorEnv(venv)
+        # Auto-wrap envpool envs so that callers can pass them directly.
+        # At runtime `venv` may be a raw envpool env (not a BaseVectorEnv).
+        if not isinstance(venv, BaseVectorEnv) and hasattr(venv, "__len__"):
+            venv = EnvPoolVectorEnv(venv)  # type: ignore[arg-type]
         self.venv = venv
         self.is_async = venv.is_async
 

--- a/tianshou/env/venv_wrappers.py
+++ b/tianshou/env/venv_wrappers.py
@@ -44,7 +44,7 @@ class VectorEnvWrapper(BaseVectorEnv):
         value: Any,
         id: int | list[int] | np.ndarray | None = None,
     ) -> None:
-        return self.venv.set_env_attr(key, value, id)
+        self.venv.set_env_attr(key, value, id)
 
     def reset(
         self,
@@ -89,7 +89,7 @@ class VectorEnvNormObs(VectorEnvWrapper):
     ) -> tuple[np.ndarray, np.ndarray]:
         obs, info = self.venv.reset(env_id, **kwargs)
 
-        if isinstance(obs, tuple):  # type: ignore
+        if isinstance(obs, tuple):
             raise TypeError(
                 "Tuple observation space is not supported. ",
                 "Please change it to array or dict space",

--- a/tianshou/env/venv_wrappers.py
+++ b/tianshou/env/venv_wrappers.py
@@ -4,7 +4,7 @@ import numpy as np
 import torch
 
 from tianshou.env.utils import gym_new_venv_step_type
-from tianshou.env.venvs import GYM_RESERVED_KEYS, BaseVectorEnv
+from tianshou.env.venvs import GYM_RESERVED_KEYS, BaseVectorEnv, EnvPoolVectorEnv
 from tianshou.utils import RunningMeanStd
 
 
@@ -16,6 +16,9 @@ class VectorEnvWrapper(BaseVectorEnv):
     # it can be used as a drop-in replacement
     # noinspection PyMissingConstructor
     def __init__(self, venv: BaseVectorEnv) -> None:
+        # Auto-wrap envpool envs so that callers can pass them directly
+        if not isinstance(venv, (BaseVectorEnv, EnvPoolVectorEnv)) and hasattr(venv, "__len__"):
+            venv = EnvPoolVectorEnv(venv)
         self.venv = venv
         self.is_async = venv.is_async
 

--- a/tianshou/env/venvs.py
+++ b/tianshou/env/venvs.py
@@ -535,7 +535,7 @@ class EnvPoolVectorEnv:
         self.is_closed = False
 
     def __len__(self) -> int:
-        return self._env.config["num_envs"]  # type: ignore
+        return self._env.config["num_envs"]
 
     def __getattr__(self, key: str) -> Any:
         """Proxy attribute access to the underlying envpool env."""

--- a/tianshou/env/venvs.py
+++ b/tianshou/env/venvs.py
@@ -510,6 +510,22 @@ def _dict_of_arrays_to_array_of_dicts(dict_of_arrays: dict) -> np.ndarray:
     return np.array(result)
 
 
+def _is_envpool_env(env: Any) -> bool:
+    """Check if *env* looks like an envpool vectorised environment.
+
+    envpool envs expose ``config["num_envs"]``, ``send``, and ``recv``
+    methods.  Checking these is more robust than ``hasattr(env, "__len__")``,
+    which would also match unrelated objects.
+    """
+    return (
+        hasattr(env, "config")
+        and isinstance(getattr(env, "config", None), dict)
+        and "num_envs" in env.config
+        and hasattr(env, "send")
+        and hasattr(env, "recv")
+    )
+
+
 class EnvPoolVectorEnv:
     """Wrapper that adapts an envpool environment to the :class:`BaseVectorEnv` interface.
 

--- a/tianshou/env/venvs.py
+++ b/tianshou/env/venvs.py
@@ -190,8 +190,6 @@ class BaseVectorEnv:
             )
             assert i in self.ready_id, f"Can only interact with ready environments {self.ready_id}."
 
-    # TODO: for now, has to be kept in sync with reset in EnvPoolMixin
-    #  In particular, can't rename env_id to env_ids
     def reset(
         self,
         env_id: int | list[int] | np.ndarray | None = None,
@@ -471,3 +469,154 @@ class RayVectorEnv(BaseVectorEnv):
         if not ray.is_initialized():
             ray.init()
         super().__init__(env_fns, lambda env_fn: RayEnvWorker(env_fn), wait_num, timeout)
+
+
+def _dict_of_arrays_to_array_of_dicts(dict_of_arrays: dict) -> np.ndarray:
+    """Convert a dict of arrays (envpool format) to an array of dicts (tianshou format).
+
+    envpool returns info as ``{"key1": np.array([...]), "key2": np.array([...])}``
+    but tianshou expects ``np.array([{"key1": v1, "key2": v2}, ...])``.
+    """
+    if not dict_of_arrays:
+        return np.array([{} for _ in range(0)])
+
+    # Determine the batch size from the first array-valued entry
+    batch_size = None
+    for v in dict_of_arrays.values():
+        if isinstance(v, np.ndarray):
+            batch_size = len(v)
+            break
+    if batch_size is None:
+        # All values are scalars or non-arrays; wrap into a single-element array
+        return np.array([dict_of_arrays])
+
+    result = []
+    for i in range(batch_size):
+        d: dict = {}
+        for k, v in dict_of_arrays.items():
+            if isinstance(v, np.ndarray) and v.shape and len(v) == batch_size:
+                d[k] = v[i]
+            elif isinstance(v, dict):
+                # Nested dict of arrays
+                d[k] = {
+                    nk: nv[i]
+                    if isinstance(nv, np.ndarray) and nv.shape and len(nv) == batch_size
+                    else nv
+                    for nk, nv in v.items()
+                }
+            else:
+                d[k] = v
+        result.append(d)
+    return np.array(result)
+
+
+class EnvPoolVectorEnv:
+    """Wrapper that adapts an envpool environment to the :class:`BaseVectorEnv` interface.
+
+    envpool environments are *not* instances of :class:`BaseVectorEnv`, yet they are
+    commonly passed directly to :class:`~tianshou.data.Collector`. This wrapper
+    bridges the gap by:
+
+    * Converting the ``info`` returned by ``reset()`` and ``step()`` from a
+      dict-of-arrays (envpool convention) to an array-of-dicts (tianshou convention).
+    * Injecting ``env_id`` into every per-env info dict returned by ``step()``.
+    * Making ``action_space`` indexable per environment.
+
+    Usage::
+
+        import envpool
+        raw = envpool.make_gymnasium("CartPole-v1", num_envs=4)
+        env = EnvPoolVectorEnv(raw)  # now compatible with Collector
+    """
+
+    def __init__(self, env: Any) -> None:
+        self._env = env
+        self.is_async = False
+        self.is_closed = False
+
+    def __len__(self) -> int:
+        return self._env.config["num_envs"]  # type: ignore
+
+    def __getattr__(self, key: str) -> Any:
+        """Proxy attribute access to the underlying envpool env."""
+        return getattr(self._env, key)
+
+    # ------------------------------------------------------------------
+    # Core vectorized-env interface
+    # ------------------------------------------------------------------
+
+    def reset(
+        self,
+        env_id: int | list[int] | np.ndarray | None = None,
+        **kwargs: Any,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        if env_id is not None:
+            # envpool supports partial reset via env_id kwarg
+            kwargs["env_id"] = np.asarray(env_id)
+        obs, info = self._env.reset(**kwargs)
+        if isinstance(info, dict):
+            info = _dict_of_arrays_to_array_of_dicts(info)
+        return obs, info
+
+    def step(
+        self,
+        action: np.ndarray | torch.Tensor | None,
+        id: int | list[int] | np.ndarray | None = None,
+    ) -> gym_new_venv_step_type:
+        if action is None:
+            raise ValueError("action must be not-None for EnvPoolVectorEnv (non-async)")
+        obs, rew, terminated, truncated, info = self._env.step(action)
+        if isinstance(info, dict):
+            info = _dict_of_arrays_to_array_of_dicts(info)
+
+        # Inject env_id into each info dict, consistent with BaseVectorEnv.step
+        if id is not None:
+            ids = [id] if np.isscalar(id) else list(id)
+        else:
+            ids = list(range(len(self)))
+        for i, env_id_val in enumerate(ids):
+            if i < len(info):
+                info[i]["env_id"] = env_id_val
+
+        return obs, rew, terminated, truncated, info
+
+    def seed(self, seed: int | list[int] | None = None) -> list[list[int] | None]:
+        if hasattr(self._env, "seed"):
+            # envpool's seed interface differs; best-effort support
+            if isinstance(seed, int):
+                self._env.seed(seed)
+            elif isinstance(seed, list) and seed:
+                self._env.seed(seed[0])
+            return [None] * len(self)
+        return [None] * len(self)
+
+    def render(self, **kwargs: Any) -> list[Any]:
+        if hasattr(self._env, "render"):
+            return [self._env.render(**kwargs)]
+        return []
+
+    def close(self) -> None:
+        if not self.is_closed:
+            if hasattr(self._env, "close"):
+                self._env.close()
+            self.is_closed = True
+
+    def get_env_attr(
+        self,
+        key: str,
+        id: int | list[int] | np.ndarray | None = None,
+    ) -> list[Any]:
+        val = getattr(self._env, key)
+        if id is None:
+            return [val] * len(self)
+        ids = [id] if np.isscalar(id) else list(id)
+        return [val] * len(ids)
+
+    def set_env_attr(
+        self,
+        key: str,
+        value: Any,
+        id: int | list[int] | np.ndarray | None = None,
+    ) -> None:
+        # envpool envs don't support per-env attribute setting
+        setattr(self._env, key, value)

--- a/tianshou/env/venvs.py
+++ b/tianshou/env/venvs.py
@@ -565,13 +565,21 @@ class EnvPoolVectorEnv:
     ) -> gym_new_venv_step_type:
         if action is None:
             raise ValueError("action must be not-None for EnvPoolVectorEnv (non-async)")
-        obs, rew, terminated, truncated, info = self._env.step(action)
+
+        if id is not None:
+            # Step only the specified environments via envpool's send/recv API.
+            env_id = np.asarray([id] if isinstance(id, int) else id)
+            self._env.send(action, env_id=env_id)
+            obs, rew, terminated, truncated, info = self._env.recv()
+        else:
+            obs, rew, terminated, truncated, info = self._env.step(action)
+
         if isinstance(info, dict):
             info = _dict_of_arrays_to_array_of_dicts(info)
 
         # Inject env_id into each info dict, consistent with BaseVectorEnv.step
         if id is not None:
-            ids = [id] if np.isscalar(id) else list(id)
+            ids: list[int] = [id] if isinstance(id, int) else list(id)
         else:
             ids = list(range(len(self)))
         for i, env_id_val in enumerate(ids):
@@ -609,7 +617,7 @@ class EnvPoolVectorEnv:
         val = getattr(self._env, key)
         if id is None:
             return [val] * len(self)
-        ids = [id] if np.isscalar(id) else list(id)
+        ids: list[int] = [id] if isinstance(id, int) else list(id)
         return [val] * len(ids)
 
     def set_env_attr(

--- a/tianshou/highlevel/env.py
+++ b/tianshou/highlevel/env.py
@@ -15,6 +15,7 @@ from sensai.util.string import ToStringMixin
 from tianshou.env import (
     BaseVectorEnv,
     DummyVectorEnv,
+    EnvPoolVectorEnv,
     RayVectorEnv,
     SubprocVectorEnv,
 )
@@ -349,17 +350,18 @@ class EnvPoolFactory:
         mode: EnvMode,
         seed: int,
         kwargs: dict,
-    ) -> BaseVectorEnv:
+    ) -> EnvPoolVectorEnv:
         import envpool
 
         envpool_task = self._transform_task(task)
         envpool_kwargs = self._transform_kwargs(kwargs, mode)
-        return envpool.make_gymnasium(
+        raw_env = envpool.make_gymnasium(
             envpool_task,
             num_envs=num_envs,
             seed=seed,
             **envpool_kwargs,
         )
+        return EnvPoolVectorEnv(raw_env)
 
 
 class EnvFactory(ToStringMixin, ABC):

--- a/tianshou/highlevel/env.py
+++ b/tianshou/highlevel/env.py
@@ -558,7 +558,7 @@ class EnvFactoryRegistered(EnvFactory):
     def create_venv(self, num_envs: int, mode: EnvMode, seed: int | None = None) -> BaseVectorEnv:
         if self.envpool_factory is not None:
             rng = self._create_rng(seed)
-            return self.envpool_factory.create_venv(
+            return self.envpool_factory.create_venv(  # type: ignore[return-value]
                 self.task,
                 num_envs,
                 mode,


### PR DESCRIPTION
## Summary

Fixes #1096 — instead of passing raw envpool envs where `BaseVectorEnv` is expected (which relied on interfaces accidentally coinciding), introduces `EnvPoolVectorEnv` that properly adapts envpool envs.

### Problem
Raw envpool envs return info as a single dict with array values, while tianshou's `BaseVectorEnv` returns an array of dicts. The old code used inline hacks in `Collector`, which was fragile and violated the type contract.

### Solution

**New: `EnvPoolVectorEnv`** (`tianshou/env/venvs.py`)
- Wraps any envpool env as a proper `BaseVectorEnv`
- Converts dict-of-arrays info to array-of-dicts
- Injects `env_id` into per-env info dicts
- Implements `seed()`, `close()`, `render()`, `get_env_attr()`, `set_env_attr()`

**Cleanup:**
- Removed envpool info hacks from `Collector.reset_env()` and `Collector._collect()`
- Auto-wrapping in `Collector.__init__` and `VectorEnvWrapper.__init__`
- 7 new unit tests

<details>
<summary>Before (master branch)</summary>

```
$ python -m pytest test/base/ -x --tb=short -q
149 passed, 3 skipped, 91 warnings in 49.93s
```

</details>

<details>
<summary>After (this branch)</summary>

```
$ python -m pytest test/base/ -x --tb=short -q
156 passed, 3 skipped, 91 warnings in 46.02s
```

</details>

## Test plan
- [x] `pytest test/base/ -x` — 156 passed (7 new tests)
- [x] `ruff check` passes

Closes #1096