### PR TITLE
fix: warn on implicit zero-fill and preserve empty dicts in Batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+**Fixes:**
+* `data`:
+  * `Batch`: Warn on implicit zero-fill when stacking batches with mismatched keys, and preserve empty dicts instead of silently dropping them #1296
+
 # Release 2.0.1 (2026-04-02)
 
 This is a maintenance release.

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -1,5 +1,6 @@
 import copy
 import pickle
+import warnings
 from itertools import starmap
 from typing import Any, cast
 
@@ -102,7 +103,9 @@ def test_batch() -> None:
     assert batch_item.a.c == batch_dict["c"]
     assert isinstance(batch_item.a.d, torch.Tensor)
     assert batch_item.a.d == batch_dict["d"]
-    batch2 = Batch(a=[{"b": np.float64(1.0), "c": np.zeros(1), "d": Batch(e=np.array(3.0))}])
+    batch2 = Batch(
+        a=[{"b": np.float64(1.0), "c": np.zeros(1), "d": Batch(e=np.array(3.0))}]
+    )
     assert len(batch2) == 1
     assert Batch().shape == []
     assert Batch(a=1).shape == []
@@ -142,7 +145,9 @@ def test_batch() -> None:
     assert len(batch2_sum.a.d.f.get_keys()) == 0
     with pytest.raises(TypeError):
         batch2 += [1]  # type: ignore  # error is raised explicitly
-    batch3 = Batch(a={"c": np.zeros(1), "d": Batch(e=np.array([0.0]), f=np.array([3.0]))})
+    batch3 = Batch(
+        a={"c": np.zeros(1), "d": Batch(e=np.array([0.0]), f=np.array([3.0]))}
+    )
     batch3.a.d[0] = {"e": 4.0}
     assert batch3.a.d.e[0] == 4.0
     batch3.a.d[0] = Batch(f=5.0)
@@ -279,7 +284,9 @@ def test_batch_cat_and_stack() -> None:
     b34_stack = Batch.stack((b3, b4), axis=1)
     assert np.all(b34_stack.a == np.stack((b3.a, b4.a), axis=1))
     assert np.all(b34_stack.c.d == list(map(list, zip(b3.c.d, b4.c.d, strict=True))))
-    b5_dict = np.array([{"a": False, "b": {"c": 2.0, "d": 1.0}}, {"a": True, "b": {"c": 3.0}}])
+    b5_dict = np.array(
+        [{"a": False, "b": {"c": 2.0, "d": 1.0}}, {"a": True, "b": {"c": 3.0}}]
+    )
     b5 = Batch(b5_dict)
     assert b5.a[0] == np.array(False)
     assert b5.a[1] == np.array(True)
@@ -349,7 +356,9 @@ def test_batch_cat_and_stack() -> None:
 def test_utils_to_torch_numpy() -> None:
     batch = Batch(
         a=np.float64(1.0),
-        b=Batch(c=np.ones((1,), dtype=np.float32), d=torch.ones((1,), dtype=torch.float64)),
+        b=Batch(
+            c=np.ones((1,), dtype=np.float32), d=torch.ones((1,), dtype=torch.float64)
+        ),
     )
     a_torch_float = to_torch(batch.a, dtype=torch.float32)
     assert a_torch_float.dtype == torch.float32
@@ -451,7 +460,9 @@ def test_batch_copy() -> None:
 
 
 def test_batch_empty() -> None:
-    b5_dict = np.array([{"a": False, "b": {"c": 2.0, "d": 1.0}}, {"a": True, "b": {"c": 3.0}}])
+    b5_dict = np.array(
+        [{"a": False, "b": {"c": 2.0, "d": 1.0}}, {"a": True, "b": {"c": 3.0}}]
+    )
     b5 = Batch(b5_dict)
     b5[1] = Batch.empty(b5[0])
     assert np.allclose(b5.a, [False, False])
@@ -487,7 +498,9 @@ def test_batch_empty() -> None:
 
 
 def test_batch_standard_compatibility() -> None:
-    batch = Batch(a=np.array([[1.0, 2.0], [3.0, 4.0]]), b=Batch(), c=np.array([5.0, 6.0]))
+    batch = Batch(
+        a=np.array([[1.0, 2.0], [3.0, 4.0]]), b=Batch(), c=np.array([5.0, 6.0])
+    )
     batch_mean = np.mean(batch)
     assert isinstance(batch_mean, Batch)  # type: ignore  # mypy doesn't know but it works, cf. `batch.rst`
     assert sorted(batch_mean.get_keys()) == ["a", "b", "c"]  # type: ignore
@@ -710,7 +723,9 @@ class TestBatchConversions:
         assert np.array_equal(batch_with_max.b, np.array(2))
         assert np.array_equal(batch_with_max.c.d, np.array(3))
 
-        batch_array_added = batch.apply_values_transform(lambda x: x + np.array([1, 2, 3]))
+        batch_array_added = batch.apply_values_transform(
+            lambda x: x + np.array([1, 2, 3])
+        )
         assert np.array_equal(batch_array_added.a, np.array([2, 3, 4]))
         assert np.array_equal(batch_array_added.c.d, np.array([2, 4, 6]))
 
@@ -779,14 +794,18 @@ class TestBatchConversions:
             ),
             (
                 Independent(
-                    Normal(loc=torch.tensor([0.0, 1.0]), scale=torch.tensor([1.0, 2.0])),
+                    Normal(
+                        loc=torch.tensor([0.0, 1.0]), scale=torch.tensor([1.0, 2.0])
+                    ),
                     0,
                 ),
                 (2,),
             ),
         ],
     )
-    def test_dist_to_atleast_2d(dist: Distribution, expected_batch_shape: tuple[int]) -> None:
+    def test_dist_to_atleast_2d(
+        dist: Distribution, expected_batch_shape: tuple[int]
+    ) -> None:
         result = dist_to_atleast_2d(dist)
         assert result.batch_shape == expected_batch_shape
 
@@ -868,11 +887,15 @@ class TestAssignment:
     @staticmethod
     def test_assign_subarray_new_key() -> None:
         batch = Batch(a=[4, 5, 6], b=[7, 8, 9], c={"d": np.array([1, 2, 3])})
-        batch.set_array_at_key(np.array([1, 2]), "new_key", index=[0, 1], default_value=0)
+        batch.set_array_at_key(
+            np.array([1, 2]), "new_key", index=[0, 1], default_value=0
+        )
         assert np.array_equal(batch.new_key, np.array([1, 2, 0]))
         # with float, None can be cast to NaN
         batch.set_array_at_key(np.array([1.0, 2.0]), "new_key2", index=[0, 1])
-        assert np.array_equal(batch.new_key2, np.array([1.0, 2.0, np.nan]), equal_nan=True)
+        assert np.array_equal(
+            batch.new_key2, np.array([1.0, 2.0, np.nan]), equal_nan=True
+        )
 
     @staticmethod
     def test_isnull() -> None:
@@ -902,8 +925,12 @@ class TestAssignment:
         ).apply_values_transform(
             np.atleast_1d,
         )
-        batch2 = Batch(a=[4, 5, 6, 7], b=[7, 8, None, 10], c={"d": np.array([None, 2, 3, 4])})
-        assert batch2.dropnull() == Batch(a=[5, 7], b=[8, 10], c={"d": np.array([2, 4])})
+        batch2 = Batch(
+            a=[4, 5, 6, 7], b=[7, 8, None, 10], c={"d": np.array([None, 2, 3, 4])}
+        )
+        assert batch2.dropnull() == Batch(
+            a=[5, 7], b=[8, 10], c={"d": np.array([2, 4])}
+        )
         batch_no_nan = Batch(a=[4, 5, 6], b=[7, 8, 9], c={"d": np.array([1, 2, 3])})
         assert batch_no_nan.dropnull() == batch_no_nan
 
@@ -918,7 +945,9 @@ class TestSlicing:
         selected_idx = [1, 3]
         sliced_batch = batch[selected_idx]
         sliced_probs = cat_probs[selected_idx]
-        assert torch.allclose(sliced_batch.dist.probs, Categorical(probs=sliced_probs).probs)
+        assert torch.allclose(
+            sliced_batch.dist.probs, Categorical(probs=sliced_probs).probs
+        )
         assert torch.allclose(
             Categorical(probs=sliced_probs).probs,
             get_sliced_dist(dist, selected_idx).probs,
@@ -934,7 +963,9 @@ class TestSlicing:
         assert batch_sliced.b.c == np.array(3)
 
     @staticmethod
-    @pytest.mark.parametrize("index", ([0, 1], np.array([0, 1]), torch.tensor([0, 1]), slice(0, 2)))
+    @pytest.mark.parametrize(
+        "index", ([0, 1], np.array([0, 1]), torch.tensor([0, 1]), slice(0, 2))
+    )
     def test_getitem_with_slice_gives_subslice(index: IndexType) -> None:
         batch = Batch(a=[1, 2, 3], b=Batch(c=torch.tensor([4, 5, 6])))
         batch_sliced = batch[index]
@@ -943,7 +974,9 @@ class TestSlicing:
 
     @staticmethod
     def test_len_batch_with_dist() -> None:
-        batch_with_dist = Batch(a=[1, 2, 3], dist=Categorical(torch.ones((3, 3))), b=None)
+        batch_with_dist = Batch(
+            a=[1, 2, 3], dist=Categorical(torch.ones((3, 3))), b=None
+        )
         batch_with_dist_sliced = batch_with_dist[:2]
         assert batch_with_dist_sliced.b is None
         assert len(batch_with_dist_sliced) == 2
@@ -956,3 +989,130 @@ class TestSlicing:
         with pytest.raises(TypeError):
             # scalar batches have no len
             len(batch_with_dist[0])
+
+
+class TestBatchNoneAndEmptyHandling:
+    """Tests for issues #1088 (None replaced with 0) and #1089 (empty dict dropped)."""
+
+    @staticmethod
+    def test_empty_dict_preserves_length() -> None:
+        """Issue #1089: mixing empty and non-empty dicts should preserve length."""
+        b = Batch(info=[{"a": 1}, {}])
+        assert len(b.info) == 2
+        assert np.array_equal(b.info.a, np.array([1, 0]))
+
+    @staticmethod
+    def test_empty_dict_at_beginning() -> None:
+        """Issue #1089: empty dict at index 0 should not be dropped."""
+        b = Batch(info=[{}, {"a": 1}])
+        assert len(b.info) == 2
+        assert np.array_equal(b.info.a, np.array([0, 1]))
+
+    @staticmethod
+    def test_multiple_empty_dicts() -> None:
+        """Issue #1089: multiple empty dicts interspersed should all be preserved."""
+        b = Batch(info=[{}, {"a": 1}, {}, {"a": 2}, {}])
+        assert len(b.info) == 5
+        assert np.array_equal(b.info.a, np.array([0, 1, 0, 2, 0]))
+
+    @staticmethod
+    def test_all_empty_dicts_stack() -> None:
+        """Stacking all-empty dicts/Batches should still return an empty Batch."""
+        b = Batch.stack([Batch(), Batch(), Batch()])
+        assert len(b.get_keys()) == 0
+
+    @staticmethod
+    def test_all_empty_dicts_in_list() -> None:
+        """A list of all empty dicts should produce an empty Batch."""
+        b = Batch(info=[{}, {}, {}])
+        assert len(b.info.get_keys()) == 0
+
+    @staticmethod
+    def test_empty_dict_with_nested_batch() -> None:
+        """Issue #1089: empty dicts mixed with nested structures."""
+        b = Batch(info=[{"inner": {"x": 1}}, {}])
+        assert len(b.info) == 2
+        assert len(b.info.inner) == 2
+        assert np.array_equal(b.info.inner.x, np.array([1, 0]))
+
+    @staticmethod
+    def test_missing_key_warns_for_numeric_in_setitem() -> None:
+        """Issue #1088: __setitem__ should warn when filling 0 for missing numeric key."""
+        b = Batch(a=[1, 2], env_num=[3, 4])
+        with pytest.warns(
+            UserWarning,
+            match=r"Key 'env_num' is not found in the value Batch",
+        ):
+            b[1] = Batch(a=99)
+        assert b.env_num[1] == 0
+        assert b.a[1] == 99
+
+    @staticmethod
+    def test_missing_key_warns_for_numeric_in_stack() -> None:
+        """Issue #1088: stack_ should warn when filling 0 for missing numeric key."""
+        with pytest.warns(
+            UserWarning,
+            match=r"Key 'env_num' is not present in all batches during stacking",
+        ):
+            b = Batch(info=[{"a": 1, "env_num": 3}, {"a": 2}])
+        assert np.array_equal(b.info.a, np.array([1, 2]))
+        assert np.array_equal(b.info.env_num, np.array([3, 0]))
+
+    @staticmethod
+    def test_missing_key_no_warn_for_object_type() -> None:
+        """Non-numeric types (object arrays) use None and should not warn."""
+        b = Batch(a=["hello", "world"], b=["x", "y"])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            b[0] = Batch(a="replaced")
+        assert b.a[0] == "replaced"
+        assert b.b[0] is None
+
+    @staticmethod
+    def test_missing_key_batch_type_fills_empty() -> None:
+        """Batch-type values use empty Batch() for missing key at the outer level."""
+        b = Batch(a=[1, 2], sub=Batch())
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            # 'sub' is an empty Batch, so assigning with missing 'sub' triggers
+            # the Batch branch (not numeric), which fills with Batch() without warning
+            b[0] = Batch(a=99)
+        assert b.a[0] == 99
+
+    @staticmethod
+    def test_missing_key_torch_tensor_warns() -> None:
+        """Issue #1088: torch tensors should also warn when filling 0."""
+        b = Batch(a=torch.tensor([1, 2]), extra=torch.tensor([3, 4]))
+        with pytest.warns(
+            UserWarning,
+            match=r"Key 'extra' is not found in the value Batch",
+        ):
+            b[0] = Batch(a=torch.tensor(99))
+        assert b.extra[0] == 0
+
+    @staticmethod
+    def test_stack_partial_keys_preserves_values() -> None:
+        """Partial keys during stack should correctly set present values."""
+        with pytest.warns(UserWarning):
+            b = Batch.stack(
+                [
+                    Batch(a=1, b=2),
+                    Batch(a=3),
+                ]
+            )
+        assert np.array_equal(b.a, np.array([1, 3]))
+        assert np.array_equal(b.b, np.array([2, 0]))
+
+    @staticmethod
+    def test_hasnull_detects_object_none_but_not_numeric_zero() -> None:
+        """Verify that hasnull works correctly: detects None in object arrays,
+        but cannot detect 0-filled numeric missing values (documenting current behavior).
+        """
+        # Object array with None is detectable
+        b_obj = Batch(a=[1, 2], b=["x", None])
+        assert b_obj.hasnull() is True
+
+        # Numeric array with 0-filled missing is NOT detectable by hasnull
+        with pytest.warns(UserWarning):
+            b_num = Batch.stack([Batch(a=1, env_num=3), Batch(a=2)])
+        assert b_num.hasnull() is False  # 0 is not null

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -103,9 +103,7 @@ def test_batch() -> None:
     assert batch_item.a.c == batch_dict["c"]
     assert isinstance(batch_item.a.d, torch.Tensor)
     assert batch_item.a.d == batch_dict["d"]
-    batch2 = Batch(
-        a=[{"b": np.float64(1.0), "c": np.zeros(1), "d": Batch(e=np.array(3.0))}]
-    )
+    batch2 = Batch(a=[{"b": np.float64(1.0), "c": np.zeros(1), "d": Batch(e=np.array(3.0))}])
     assert len(batch2) == 1
     assert Batch().shape == []
     assert Batch(a=1).shape == []
@@ -145,9 +143,7 @@ def test_batch() -> None:
     assert len(batch2_sum.a.d.f.get_keys()) == 0
     with pytest.raises(TypeError):
         batch2 += [1]  # type: ignore  # error is raised explicitly
-    batch3 = Batch(
-        a={"c": np.zeros(1), "d": Batch(e=np.array([0.0]), f=np.array([3.0]))}
-    )
+    batch3 = Batch(a={"c": np.zeros(1), "d": Batch(e=np.array([0.0]), f=np.array([3.0]))})
     batch3.a.d[0] = {"e": 4.0}
     assert batch3.a.d.e[0] == 4.0
     batch3.a.d[0] = Batch(f=5.0)
@@ -284,9 +280,7 @@ def test_batch_cat_and_stack() -> None:
     b34_stack = Batch.stack((b3, b4), axis=1)
     assert np.all(b34_stack.a == np.stack((b3.a, b4.a), axis=1))
     assert np.all(b34_stack.c.d == list(map(list, zip(b3.c.d, b4.c.d, strict=True))))
-    b5_dict = np.array(
-        [{"a": False, "b": {"c": 2.0, "d": 1.0}}, {"a": True, "b": {"c": 3.0}}]
-    )
+    b5_dict = np.array([{"a": False, "b": {"c": 2.0, "d": 1.0}}, {"a": True, "b": {"c": 3.0}}])
     b5 = Batch(b5_dict)
     assert b5.a[0] == np.array(False)
     assert b5.a[1] == np.array(True)
@@ -356,9 +350,7 @@ def test_batch_cat_and_stack() -> None:
 def test_utils_to_torch_numpy() -> None:
     batch = Batch(
         a=np.float64(1.0),
-        b=Batch(
-            c=np.ones((1,), dtype=np.float32), d=torch.ones((1,), dtype=torch.float64)
-        ),
+        b=Batch(c=np.ones((1,), dtype=np.float32), d=torch.ones((1,), dtype=torch.float64)),
     )
     a_torch_float = to_torch(batch.a, dtype=torch.float32)
     assert a_torch_float.dtype == torch.float32
@@ -460,9 +452,7 @@ def test_batch_copy() -> None:
 
 
 def test_batch_empty() -> None:
-    b5_dict = np.array(
-        [{"a": False, "b": {"c": 2.0, "d": 1.0}}, {"a": True, "b": {"c": 3.0}}]
-    )
+    b5_dict = np.array([{"a": False, "b": {"c": 2.0, "d": 1.0}}, {"a": True, "b": {"c": 3.0}}])
     b5 = Batch(b5_dict)
     b5[1] = Batch.empty(b5[0])
     assert np.allclose(b5.a, [False, False])
@@ -498,9 +488,7 @@ def test_batch_empty() -> None:
 
 
 def test_batch_standard_compatibility() -> None:
-    batch = Batch(
-        a=np.array([[1.0, 2.0], [3.0, 4.0]]), b=Batch(), c=np.array([5.0, 6.0])
-    )
+    batch = Batch(a=np.array([[1.0, 2.0], [3.0, 4.0]]), b=Batch(), c=np.array([5.0, 6.0]))
     batch_mean = np.mean(batch)
     assert isinstance(batch_mean, Batch)  # type: ignore  # mypy doesn't know but it works, cf. `batch.rst`
     assert sorted(batch_mean.get_keys()) == ["a", "b", "c"]  # type: ignore
@@ -723,9 +711,7 @@ class TestBatchConversions:
         assert np.array_equal(batch_with_max.b, np.array(2))
         assert np.array_equal(batch_with_max.c.d, np.array(3))
 
-        batch_array_added = batch.apply_values_transform(
-            lambda x: x + np.array([1, 2, 3])
-        )
+        batch_array_added = batch.apply_values_transform(lambda x: x + np.array([1, 2, 3]))
         assert np.array_equal(batch_array_added.a, np.array([2, 3, 4]))
         assert np.array_equal(batch_array_added.c.d, np.array([2, 4, 6]))
 
@@ -794,18 +780,14 @@ class TestBatchConversions:
             ),
             (
                 Independent(
-                    Normal(
-                        loc=torch.tensor([0.0, 1.0]), scale=torch.tensor([1.0, 2.0])
-                    ),
+                    Normal(loc=torch.tensor([0.0, 1.0]), scale=torch.tensor([1.0, 2.0])),
                     0,
                 ),
                 (2,),
             ),
         ],
     )
-    def test_dist_to_atleast_2d(
-        dist: Distribution, expected_batch_shape: tuple[int]
-    ) -> None:
+    def test_dist_to_atleast_2d(dist: Distribution, expected_batch_shape: tuple[int]) -> None:
         result = dist_to_atleast_2d(dist)
         assert result.batch_shape == expected_batch_shape
 
@@ -887,15 +869,11 @@ class TestAssignment:
     @staticmethod
     def test_assign_subarray_new_key() -> None:
         batch = Batch(a=[4, 5, 6], b=[7, 8, 9], c={"d": np.array([1, 2, 3])})
-        batch.set_array_at_key(
-            np.array([1, 2]), "new_key", index=[0, 1], default_value=0
-        )
+        batch.set_array_at_key(np.array([1, 2]), "new_key", index=[0, 1], default_value=0)
         assert np.array_equal(batch.new_key, np.array([1, 2, 0]))
         # with float, None can be cast to NaN
         batch.set_array_at_key(np.array([1.0, 2.0]), "new_key2", index=[0, 1])
-        assert np.array_equal(
-            batch.new_key2, np.array([1.0, 2.0, np.nan]), equal_nan=True
-        )
+        assert np.array_equal(batch.new_key2, np.array([1.0, 2.0, np.nan]), equal_nan=True)
 
     @staticmethod
     def test_isnull() -> None:
@@ -925,12 +903,8 @@ class TestAssignment:
         ).apply_values_transform(
             np.atleast_1d,
         )
-        batch2 = Batch(
-            a=[4, 5, 6, 7], b=[7, 8, None, 10], c={"d": np.array([None, 2, 3, 4])}
-        )
-        assert batch2.dropnull() == Batch(
-            a=[5, 7], b=[8, 10], c={"d": np.array([2, 4])}
-        )
+        batch2 = Batch(a=[4, 5, 6, 7], b=[7, 8, None, 10], c={"d": np.array([None, 2, 3, 4])})
+        assert batch2.dropnull() == Batch(a=[5, 7], b=[8, 10], c={"d": np.array([2, 4])})
         batch_no_nan = Batch(a=[4, 5, 6], b=[7, 8, 9], c={"d": np.array([1, 2, 3])})
         assert batch_no_nan.dropnull() == batch_no_nan
 
@@ -945,9 +919,7 @@ class TestSlicing:
         selected_idx = [1, 3]
         sliced_batch = batch[selected_idx]
         sliced_probs = cat_probs[selected_idx]
-        assert torch.allclose(
-            sliced_batch.dist.probs, Categorical(probs=sliced_probs).probs
-        )
+        assert torch.allclose(sliced_batch.dist.probs, Categorical(probs=sliced_probs).probs)
         assert torch.allclose(
             Categorical(probs=sliced_probs).probs,
             get_sliced_dist(dist, selected_idx).probs,
@@ -963,9 +935,7 @@ class TestSlicing:
         assert batch_sliced.b.c == np.array(3)
 
     @staticmethod
-    @pytest.mark.parametrize(
-        "index", ([0, 1], np.array([0, 1]), torch.tensor([0, 1]), slice(0, 2))
-    )
+    @pytest.mark.parametrize("index", ([0, 1], np.array([0, 1]), torch.tensor([0, 1]), slice(0, 2)))
     def test_getitem_with_slice_gives_subslice(index: IndexType) -> None:
         batch = Batch(a=[1, 2, 3], b=Batch(c=torch.tensor([4, 5, 6])))
         batch_sliced = batch[index]
@@ -974,9 +944,7 @@ class TestSlicing:
 
     @staticmethod
     def test_len_batch_with_dist() -> None:
-        batch_with_dist = Batch(
-            a=[1, 2, 3], dist=Categorical(torch.ones((3, 3))), b=None
-        )
+        batch_with_dist = Batch(a=[1, 2, 3], dist=Categorical(torch.ones((3, 3))), b=None)
         batch_with_dist_sliced = batch_with_dist[:2]
         assert batch_with_dist_sliced.b is None
         assert len(batch_with_dist_sliced) == 2

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -1145,13 +1145,9 @@ class Batch(BatchProtocol):
                     indices_missing_keys[key].append(i)
                     continue
                 value = batch.get(key)
-                # TODO: fix code/annotations s.t. the ignores can be removed
-                if (
-                    isinstance(value, Batch)  # type: ignore
-                    and len(value.get_keys()) == 0  # type: ignore
-                ):
+                if isinstance(value, Batch) and len(value.get_keys()) == 0:
                     indices_missing_keys[key].append(i)
-                    continue  # type: ignore
+                    continue
                 try:
                     self.__dict__[key][i] = value
                 except KeyError:

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -1140,19 +1140,37 @@ class Batch(BatchProtocol):
         if keys_partial:
             indices_missing_keys: dict[str, list[int]] = {key: [] for key in keys_partial}
         for key in keys_partial:
+            # Collect all values for this partial key; missing entries use Batch()
+            key_values: list[Batch | Any] = []
+            has_nested_batch = False
             for i, batch in enumerate(batches):
                 if key not in batch.__dict__:
                     indices_missing_keys[key].append(i)
+                    key_values.append(Batch())
                     continue
                 val = batch.get(key)
                 if isinstance(val, Batch) and len(val.get_keys()) == 0:
                     indices_missing_keys[key].append(i)
+                    key_values.append(Batch())
                     continue
-                try:
-                    self.__dict__[key][i] = val
-                except KeyError:
-                    self.__dict__[key] = create_value(val, len(batches))
-                    self.__dict__[key][i] = val
+                if isinstance(val, Batch | dict):
+                    has_nested_batch = True
+                key_values.append(val)
+            # For nested Batch/dict values, use recursive Batch.stack to
+            # handle differing nested keys correctly (fixes regression
+            # where Batch.stack([{"info": {"a": 1}}, {}, {"info": {"b": 2}}])
+            # would raise ValueError).
+            if has_nested_batch:
+                self.__dict__[key] = Batch.stack(key_values, axis)
+            else:
+                for i, val in enumerate(key_values):
+                    if isinstance(val, Batch) and len(val.get_keys()) == 0:
+                        continue
+                    try:
+                        self.__dict__[key][i] = val
+                    except KeyError:
+                        self.__dict__[key] = create_value(val, len(batches))
+                        self.__dict__[key][i] = val
         if keys_partial:
             _warn_numeric_zero_fill(self.__dict__, indices_missing_keys)
 

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -88,7 +88,9 @@ def _is_batch_set(obj: Any) -> bool:
         # so do not use obj.tolist()
         if obj.shape == ():
             return False
-        return obj.dtype == object and all(isinstance(element, dict | Batch) for element in obj)
+        return obj.dtype == object and all(
+            isinstance(element, dict | Batch) for element in obj
+        )
     return (
         isinstance(obj, list | tuple)
         and len(obj) > 0
@@ -166,9 +168,13 @@ def create_value(
         shape = (size, *inst.shape) if stack else (size, *inst.shape[1:])
     if isinstance(inst, np.ndarray):
         target_type = (
-            inst.dtype.type if issubclass(inst.dtype.type, np.bool_ | np.number) else object
+            inst.dtype.type
+            if issubclass(inst.dtype.type, np.bool_ | np.number)
+            else object
         )
-        return np.full(shape, fill_value=None if target_type is object else 0, dtype=target_type)
+        return np.full(
+            shape, fill_value=None if target_type is object else 0, dtype=target_type
+        )
     if isinstance(inst, torch.Tensor):
         return torch.full(shape, fill_value=0, device=inst.device, dtype=inst.dtype)
     if isinstance(inst, dict | Batch):
@@ -183,14 +189,19 @@ def create_value(
 
 
 def _assert_type_keys(keys: Iterable[str]) -> None:
-    assert all(isinstance(key, str) for key in keys), f"keys should all be string, but got {keys}"
+    assert all(
+        isinstance(key, str) for key in keys
+    ), f"keys should all be string, but got {keys}"
 
 
 def _parse_value(obj: Any) -> Union["Batch", np.ndarray, torch.Tensor] | None:
     if isinstance(obj, Batch):  # most often case
         return obj
     if (
-        (isinstance(obj, np.ndarray) and issubclass(obj.dtype.type, np.bool_ | np.number))
+        (
+            isinstance(obj, np.ndarray)
+            and issubclass(obj.dtype.type, np.bool_ | np.number)
+        )
         or isinstance(obj, torch.Tensor)
         or obj is None
     ):  # third often case
@@ -225,6 +236,52 @@ def _parse_value(obj: Any) -> Union["Batch", np.ndarray, torch.Tensor] | None:
                 "Batch does not support heterogeneous list/tuple of tensors as unique value yet.",
             ) from exception
     return obj
+
+
+def _validate_and_convert_batches(
+    batches: Sequence,
+) -> tuple[list["Batch"], bool]:
+    """Convert input batches to Batch objects, preserving empty entries (fixes #1089)."""
+    batch_list: list[Batch] = []
+    has_any_nonempty = False
+    for batch in batches:
+        if isinstance(batch, dict):
+            batch_list.append(Batch(batch) if len(batch) > 0 else Batch())
+            if len(batch) > 0:
+                has_any_nonempty = True
+        elif isinstance(batch, Batch):
+            batch_list.append(batch)
+            if len(batch.get_keys()) != 0:
+                has_any_nonempty = True
+        else:
+            raise ValueError(f"Cannot concatenate {type(batch)} in Batch.stack_")
+    return batch_list, has_any_nonempty
+
+
+def _warn_numeric_zero_fill(
+    data: dict[str, Any],
+    indices_missing_keys: dict[str, list[int]],
+) -> None:
+    """Emit a warning for keys where missing entries were filled with 0."""
+    for key, missing_indices in indices_missing_keys.items():
+        if not missing_indices:
+            continue
+        val = data.get(key)
+        if val is None:
+            continue
+        is_numeric = isinstance(val, torch.Tensor) or (
+            isinstance(val, np.ndarray)
+            and issubclass(val.dtype.type, np.bool_ | np.number)
+        )
+        if is_numeric:
+            warnings.warn(
+                f"Key '{key}' is not present in all batches during "
+                f"stacking (missing at indices {missing_indices}). "
+                f"Filling missing entries with 0 for numeric type "
+                f"({type(val).__name__}), which may mask truly missing "
+                f"values. Consider using None or np.nan to represent "
+                f"missing data explicitly.",
+            )
 
 
 def alloc_by_keys_diff(
@@ -298,7 +355,9 @@ def dist_to_atleast_2d(dist: TDistribution) -> TDistribution:
             dist.reinterpreted_batch_ndims,
         )  # type: ignore[return-value]
     else:
-        raise NotImplementedError(f"Unsupported distribution for conversion to 2D: {type(dist)}")
+        raise NotImplementedError(
+            f"Unsupported distribution for conversion to 2D: {type(dist)}"
+        )
 
 
 # Note: This is implemented as a protocol because the interface
@@ -629,11 +688,9 @@ class Batch(BatchProtocol):
 
     def __init__(
         self,
-        batch_dict: dict
-        | BatchProtocol
-        | Sequence[dict | BatchProtocol]
-        | np.ndarray
-        | None = None,
+        batch_dict: (
+            dict | BatchProtocol | Sequence[dict | BatchProtocol] | np.ndarray | None
+        ) = None,
         copy: bool = False,
         **kwargs: Any,
     ) -> None:
@@ -786,8 +843,15 @@ class Batch(BatchProtocol):
                 if isinstance(val, Batch):
                     self.__dict__[key][index] = Batch()
                 elif isinstance(val, torch.Tensor) or (
-                    isinstance(val, np.ndarray) and issubclass(val.dtype.type, np.bool_ | np.number)
+                    isinstance(val, np.ndarray)
+                    and issubclass(val.dtype.type, np.bool_ | np.number)
                 ):
+                    warnings.warn(
+                        f"Key '{key}' is not found in the value Batch during "
+                        f"item assignment. Filling with 0 for numeric type "
+                        f"({type(val).__name__}), which may mask missing values. "
+                        f"Consider using None or np.nan to represent missing data.",
+                    )
                     self.__dict__[key][index] = 0
                 else:
                     self.__dict__[key][index] = None
@@ -950,7 +1014,9 @@ class Batch(BatchProtocol):
             else:
                 # cat Batch(a=np.zeros((3, 4))) and Batch(a=Batch(b=Batch()))
                 # will fail here
-                self.__dict__[key] = _to_array_with_correct_type(np.concatenate(shared_value))
+                self.__dict__[key] = _to_array_with_correct_type(
+                    np.concatenate(shared_value)
+                )
         keys_total = set.union(*[set(batch.keys()) for batch in batches])
         keys_reserve_or_partial = set.difference(keys_total, keys_shared)
         # keys that are reserved in all batches
@@ -1039,18 +1105,8 @@ class Batch(BatchProtocol):
         return batch  # type: ignore
 
     def stack_(self, batches: Sequence[dict | BatchProtocol], axis: int = 0) -> None:
-        # check input format
-        batch_list = []
-        for batch in batches:
-            if isinstance(batch, dict):
-                if len(batch) > 0:
-                    batch_list.append(Batch(batch))
-            elif isinstance(batch, Batch):
-                if len(batch.get_keys()) != 0:
-                    batch_list.append(batch)
-            else:
-                raise ValueError(f"Cannot concatenate {type(batch)} in Batch.stack_")
-        if len(batch_list) == 0:
+        batch_list, has_any_nonempty = _validate_and_convert_batches(batches)
+        if not has_any_nonempty:
             return
         batches = batch_list
         if len(self.get_keys()) != 0:
@@ -1075,7 +1131,9 @@ class Batch(BatchProtocol):
                 self.__dict__[shared_key] = Batch.stack(value, axis)
             else:  # most often case is np.ndarray
                 try:
-                    self.__dict__[shared_key] = _to_array_with_correct_type(np.stack(value, axis))
+                    self.__dict__[shared_key] = _to_array_with_correct_type(
+                        np.stack(value, axis)
+                    )
                 except ValueError:
                     warnings.warn(
                         "You are using tensors with different shape,"
@@ -1098,9 +1156,14 @@ class Batch(BatchProtocol):
         for key in keys_reserve:
             # reserved keys
             self.__dict__[key] = Batch()
+        if keys_partial:
+            indices_missing_keys: dict[str, list[int]] = {
+                key: [] for key in keys_partial
+            }
         for key in keys_partial:
             for i, batch in enumerate(batches):
                 if key not in batch.__dict__:
+                    indices_missing_keys[key].append(i)
                     continue
                 value = batch.get(key)
                 # TODO: fix code/annotations s.t. the ignores can be removed
@@ -1108,12 +1171,15 @@ class Batch(BatchProtocol):
                     isinstance(value, Batch)  # type: ignore
                     and len(value.get_keys()) == 0  # type: ignore
                 ):
+                    indices_missing_keys[key].append(i)
                     continue  # type: ignore
                 try:
                     self.__dict__[key][i] = value
                 except KeyError:
                     self.__dict__[key] = create_value(value, len(batches))
                     self.__dict__[key][i] = value
+        if keys_partial:
+            _warn_numeric_zero_fill(self.__dict__, indices_missing_keys)
 
     @staticmethod
     def stack(batches: Sequence[dict | TBatch], axis: int = 0) -> TBatch:
@@ -1193,7 +1259,9 @@ class Batch(BatchProtocol):
             except AttributeError:
                 data_shape.append([])
         return (
-            list(map(min, zip(*data_shape, strict=False))) if len(data_shape) > 1 else data_shape[0]
+            list(map(min, zip(*data_shape, strict=False)))
+            if len(data_shape) > 1
+            else data_shape[0]
         )
 
     def split(
@@ -1251,7 +1319,9 @@ class Batch(BatchProtocol):
         arbitrary type since retrieving a single entry from a Batch a la
         `batch[0]` will return a batch with scalar values.
         """
-        return _apply_batch_values_func_recursively(self, values_transform, inplace=inplace)
+        return _apply_batch_values_func_recursively(
+            self, values_transform, inplace=inplace
+        )
 
     def set_array_at_key(
         self,
@@ -1364,7 +1434,9 @@ def _apply_batch_values_func_recursively(
     result = batch if inplace else deepcopy(batch)
     for key, val in batch.__dict__.items():
         if isinstance(val, Batch):
-            result[key] = _apply_batch_values_func_recursively(val, values_transform, inplace=False)
+            result[key] = _apply_batch_values_func_recursively(
+                val, values_transform, inplace=False
+            )
         else:
             result[key] = values_transform(val)
     if not inplace:

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -88,9 +88,7 @@ def _is_batch_set(obj: Any) -> bool:
         # so do not use obj.tolist()
         if obj.shape == ():
             return False
-        return obj.dtype == object and all(
-            isinstance(element, dict | Batch) for element in obj
-        )
+        return obj.dtype == object and all(isinstance(element, dict | Batch) for element in obj)
     return (
         isinstance(obj, list | tuple)
         and len(obj) > 0
@@ -168,13 +166,9 @@ def create_value(
         shape = (size, *inst.shape) if stack else (size, *inst.shape[1:])
     if isinstance(inst, np.ndarray):
         target_type = (
-            inst.dtype.type
-            if issubclass(inst.dtype.type, np.bool_ | np.number)
-            else object
+            inst.dtype.type if issubclass(inst.dtype.type, np.bool_ | np.number) else object
         )
-        return np.full(
-            shape, fill_value=None if target_type is object else 0, dtype=target_type
-        )
+        return np.full(shape, fill_value=None if target_type is object else 0, dtype=target_type)
     if isinstance(inst, torch.Tensor):
         return torch.full(shape, fill_value=0, device=inst.device, dtype=inst.dtype)
     if isinstance(inst, dict | Batch):
@@ -189,19 +183,14 @@ def create_value(
 
 
 def _assert_type_keys(keys: Iterable[str]) -> None:
-    assert all(
-        isinstance(key, str) for key in keys
-    ), f"keys should all be string, but got {keys}"
+    assert all(isinstance(key, str) for key in keys), f"keys should all be string, but got {keys}"
 
 
 def _parse_value(obj: Any) -> Union["Batch", np.ndarray, torch.Tensor] | None:
     if isinstance(obj, Batch):  # most often case
         return obj
     if (
-        (
-            isinstance(obj, np.ndarray)
-            and issubclass(obj.dtype.type, np.bool_ | np.number)
-        )
+        (isinstance(obj, np.ndarray) and issubclass(obj.dtype.type, np.bool_ | np.number))
         or isinstance(obj, torch.Tensor)
         or obj is None
     ):  # third often case
@@ -270,8 +259,7 @@ def _warn_numeric_zero_fill(
         if val is None:
             continue
         is_numeric = isinstance(val, torch.Tensor) or (
-            isinstance(val, np.ndarray)
-            and issubclass(val.dtype.type, np.bool_ | np.number)
+            isinstance(val, np.ndarray) and issubclass(val.dtype.type, np.bool_ | np.number)
         )
         if is_numeric:
             warnings.warn(
@@ -355,9 +343,7 @@ def dist_to_atleast_2d(dist: TDistribution) -> TDistribution:
             dist.reinterpreted_batch_ndims,
         )  # type: ignore[return-value]
     else:
-        raise NotImplementedError(
-            f"Unsupported distribution for conversion to 2D: {type(dist)}"
-        )
+        raise NotImplementedError(f"Unsupported distribution for conversion to 2D: {type(dist)}")
 
 
 # Note: This is implemented as a protocol because the interface
@@ -843,8 +829,7 @@ class Batch(BatchProtocol):
                 if isinstance(val, Batch):
                     self.__dict__[key][index] = Batch()
                 elif isinstance(val, torch.Tensor) or (
-                    isinstance(val, np.ndarray)
-                    and issubclass(val.dtype.type, np.bool_ | np.number)
+                    isinstance(val, np.ndarray) and issubclass(val.dtype.type, np.bool_ | np.number)
                 ):
                     warnings.warn(
                         f"Key '{key}' is not found in the value Batch during "
@@ -1014,9 +999,7 @@ class Batch(BatchProtocol):
             else:
                 # cat Batch(a=np.zeros((3, 4))) and Batch(a=Batch(b=Batch()))
                 # will fail here
-                self.__dict__[key] = _to_array_with_correct_type(
-                    np.concatenate(shared_value)
-                )
+                self.__dict__[key] = _to_array_with_correct_type(np.concatenate(shared_value))
         keys_total = set.union(*[set(batch.keys()) for batch in batches])
         keys_reserve_or_partial = set.difference(keys_total, keys_shared)
         # keys that are reserved in all batches
@@ -1131,9 +1114,7 @@ class Batch(BatchProtocol):
                 self.__dict__[shared_key] = Batch.stack(value, axis)
             else:  # most often case is np.ndarray
                 try:
-                    self.__dict__[shared_key] = _to_array_with_correct_type(
-                        np.stack(value, axis)
-                    )
+                    self.__dict__[shared_key] = _to_array_with_correct_type(np.stack(value, axis))
                 except ValueError:
                     warnings.warn(
                         "You are using tensors with different shape,"
@@ -1157,9 +1138,7 @@ class Batch(BatchProtocol):
             # reserved keys
             self.__dict__[key] = Batch()
         if keys_partial:
-            indices_missing_keys: dict[str, list[int]] = {
-                key: [] for key in keys_partial
-            }
+            indices_missing_keys: dict[str, list[int]] = {key: [] for key in keys_partial}
         for key in keys_partial:
             for i, batch in enumerate(batches):
                 if key not in batch.__dict__:
@@ -1259,9 +1238,7 @@ class Batch(BatchProtocol):
             except AttributeError:
                 data_shape.append([])
         return (
-            list(map(min, zip(*data_shape, strict=False)))
-            if len(data_shape) > 1
-            else data_shape[0]
+            list(map(min, zip(*data_shape, strict=False))) if len(data_shape) > 1 else data_shape[0]
         )
 
     def split(
@@ -1319,9 +1296,7 @@ class Batch(BatchProtocol):
         arbitrary type since retrieving a single entry from a Batch a la
         `batch[0]` will return a batch with scalar values.
         """
-        return _apply_batch_values_func_recursively(
-            self, values_transform, inplace=inplace
-        )
+        return _apply_batch_values_func_recursively(self, values_transform, inplace=inplace)
 
     def set_array_at_key(
         self,
@@ -1434,9 +1409,7 @@ def _apply_batch_values_func_recursively(
     result = batch if inplace else deepcopy(batch)
     for key, val in batch.__dict__.items():
         if isinstance(val, Batch):
-            result[key] = _apply_batch_values_func_recursively(
-                val, values_transform, inplace=False
-            )
+            result[key] = _apply_batch_values_func_recursively(val, values_transform, inplace=False)
         else:
             result[key] = values_transform(val)
     if not inplace:

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -1144,15 +1144,15 @@ class Batch(BatchProtocol):
                 if key not in batch.__dict__:
                     indices_missing_keys[key].append(i)
                     continue
-                value = batch.get(key)
-                if isinstance(value, Batch) and len(value.get_keys()) == 0:
+                val = batch.get(key)
+                if isinstance(val, Batch) and len(val.get_keys()) == 0:
                     indices_missing_keys[key].append(i)
                     continue
                 try:
-                    self.__dict__[key][i] = value
+                    self.__dict__[key][i] = val
                 except KeyError:
-                    self.__dict__[key] = create_value(value, len(batches))
-                    self.__dict__[key][i] = value
+                    self.__dict__[key] = create_value(val, len(batches))
+                    self.__dict__[key][i] = val
         if keys_partial:
             _warn_numeric_zero_fill(self.__dict__, indices_missing_keys)
 


### PR DESCRIPTION
## Summary

Addresses #1088 and #1089:

- **#1089 (empty dict silently dropped)**: Empty dicts in batch lists were silently dropped during `stack_`, causing index position misalignment. Now all entries are preserved via `_validate_and_convert_batches()`.
- **#1088 (None → 0 without warning)**: When `__setitem__` or `stack_` fills missing numeric keys with 0, a `UserWarning` is now emitted via `_warn_numeric_zero_fill()` to alert users that the zero value may mask truly missing data.

The fix is **backward compatible** — the zero-fill behavior itself is unchanged (changing it would break existing code), but users are now explicitly warned when it happens.

### Design decisions
- Extracted `_validate_and_convert_batches()` and `_warn_numeric_zero_fill()` as module-level helpers to keep `stack_()` complexity under ruff's C901 limit (max 20).
- Warning is `UserWarning` (not `DeprecationWarning`) since the zero-fill behavior is not being deprecated, only made visible.

<details>
<summary>Before (bug reproduction)</summary>

```
--- Bug #1089: Empty dict silently dropped ---
Input: [{"a": 1}, {}]
Result: Batch(
    info: Batch(
              a: array([1]),   # length 1 — index [1] lost
          ),
)

--- Bug #1088: None replaced by 0 silently ---
Batch(a=[1, 2, 3], b=[{"c": 1}, {}, {"c": 3}])
# b.c = array([1, 0, 3]) — 0 silently inserted at index [1], no warning
```

</details>

<details>
<summary>After (with fix)</summary>

```
--- Bug #1089: Empty dict now preserved ---
Input: [{"a": 1}, {}]
Result: Batch(
    info: Batch(
              a: array([1, 0]),   # length 2 — both indices preserved
          ),
)
Length: 2

--- Bug #1088: Warning on 0 fill ---
UserWarning: Key 'c' is not present in all batches during stacking
(missing at indices [1]). Filling missing entries with 0 for numeric
type (ndarray), which may mask truly missing values. Consider using
None or np.nan to represent missing data explicitly.
```

</details>

<details>
<summary>Test results (75 passed)</summary>

```
test/base/test_batch.py ......................................... [ 82%]
test/base/test_batch.py::TestBatchNoneAndEmptyHandling .......... [100%]
======================== 75 passed, 14 warnings in 2.31s ========================
```

</details>

## Test plan
- [x] 13 new tests in `TestBatchNoneAndEmptyHandling` covering empty dict preservation and warning behavior
- [x] All 75 existing batch tests pass
- [x] `ruff check` and `black` pass